### PR TITLE
adds menu auto-open for `/en/`

### DIFF
--- a/content/en/_index.markdown
+++ b/content/en/_index.markdown
@@ -38,3 +38,5 @@ These links alter the URL’s hash fragment and are useful when sharing a link t
 This site, like Bottlerocket, is [open source and developed in-the-open on GitHub](https://github.com/bottlerocket-os/project-website).
 If you find inaccuracies, gaps, or bugs in the documentation, [feel free to open an issue](https://github.com/bottlerocket-os/project-website/issues).
 If you know how to solve the problem yourself (and you want to make the matainers very happy), go ahead and [make a pull request](https://github.com/bottlerocket-os/project-website/pulls).
+
+{{< nav-bar-open html_id="m-enos-check" >}}

--- a/layouts/shortcodes/nav-bar-open.html
+++ b/layouts/shortcodes/nav-bar-open.html
@@ -1,0 +1,9 @@
+{{- $htmlid := .Get "html_id" -}}
+<script>
+    $(document).ready(function() {
+        let 
+            $menuitem = $('#{{ $htmlid }}');
+        
+        $menuitem.prop('checked', true);
+    });
+ </script>


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:** 

When landing on `/en/` (Documentation) the OS section is closed. This is a little confusing, so this PR adds a shortcode that will auto open the navbar when included on specific pages. Additionally, this PR includes a modification to the index of `/en/` that triggers the auto-open of on the source page for `/en/`


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
