### PR TITLE
switching action order to avoid delete of previous action

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -40,16 +40,16 @@ jobs:
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb          
       - name: Install Dart Sass
         run: sudo snap install dart-sass
-      - name: Checkout Bottlerocket repo
-        uses: actions/checkout@v3
-        with:
-          repository: bottlerocket-os/bottlerocket
-          path: bottlerocket
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Checkout Bottlerocket repo
+        uses: actions/checkout@v3
+        with:
+          repository: bottlerocket-os/bottlerocket
+          path: bottlerocket
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

Changes order of action steps as previous order caused the nested directory to trigger the final step to clear out the parent ("Deleting the contents of ... ")


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
