### PR TITLE
fixes og:description defaulting to hugo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
-baseURL = 'http://example.org/'
 languageCode = 'en-us'
 title = 'Bottlerocket'
+
+
 
 defaultContentLanguage = 'all'
 
@@ -8,7 +9,7 @@ defaultContentLanguage = 'all'
 copyright = "Copyright Amazon.com, Inc., its affiliates, or other contributors. All Rights Reserved."
 languageOverride = 'all'
 brand_link = "/"
-
+description = "Bottlerocket is a Linux-based operating system optimized for hosting containers. It’s free and open-source software, developed in the open on GitHub. Bottlerocket is installed on the machine or instance where your containers themselves are running. It is specifically designed to work with your container orchestrator (like Kubernetes) to automate the lifecycle of the containers running in your cluster. Bottlerocket runs in the cloud or in your datacenter."
 [params.ui]
 footer_about_disable = true
 navbar_logo = false


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #178

**Description of changes:**

Fixes an issue where the social preview was incorrectly defaulting to Hugo's description.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
