### PR TITLE
adds notice for old docs and redirection logic

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -296,3 +296,8 @@ footer .text-links {
     }
 }
 
+/* old docs notice */
+.pageinfo.olddocs {
+    margin-left: 0;
+    padding-bottom: 1.5rem;
+}

--- a/content/en/os/latest.markdown
+++ b/content/en/os/latest.markdown
@@ -1,0 +1,7 @@
++++
+type="docs"
+title="Latest"
+toc_hide=true
++++
+
+{{< latest-redirect >}}

--- a/data/versioned.toml
+++ b/data/versioned.toml
@@ -1,0 +1,1 @@
+sections = [ "os" ]

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,35 @@
+{{- /* get the directory of the file being rendered */ -}}
+{{- $file := print .Page.File.Dir  -}}
+{{- /* break it apart */ -}}
+{{- $parts := split $file "/" -}}
+{{- /* the first part is the section (aka product 'os', etc.) */ -}}
+{{- $sect := index $parts 0 -}}
+{{- /* is it in the site data? If so we might need to show a notice and do a rel cannonical */ -}}
+{{- if in $.Site.Data.versioned.sections $sect }}
+    {{- /* get the current version parts */ -}}
+    {{- $versions := index $.Site.Data.versions.current $sect -}}
+    {{- /* construct the string format (e.g. '1.14.x') */ -}}
+    {{- $latest := print $versions.major "." $versions.minor ".x" -}}
+    {{- /* but it into the scratch for later page elemnents */ -}}
+    {{- .Page.Scratch.Set (print $sect "-latest") $latest -}}
+    {{- /* now get the page version from the URL */ -}}
+    {{- $pageVersion := index $parts 1 }}
+    {{- /* if the page version is not equal to the latest, we've got out of date stuff */ -}}
+    {{- if (ne $latest $pageVersion) -}}
+        {{- /* create the corresponding filename for the newer version (e.g. /en/foo/1.13.x/ -> /en/foo/1.14.x/) */ -}}
+        {{- $newFileName := replace $file $pageVersion $latest -}}
+        {{- /* Setup some scratch variables for subsequent page elements */ -}}
+        {{- .Page.Scratch.Set "docs_not_current" true -}}
+        {{- .Page.Scratch.Set "docs_section_current_version" $latest -}}
+        {{- .Page.Scratch.Set "docs_this_sections_version" $pageVersion -}}
+        {{- /* if both the newer file exists */ -}}
+        {{- if fileExists $newFileName -}}
+            {{- /* Setup scratch variables that tell later element this */ -}}
+            {{- .Page.Scratch.Set "newer_docs_avail_version" $latest -}}
+            {{- .Page.Scratch.Set "newer_docs_avail_current_version" $pageVersion}}
+            {{- .Page.Scratch.Set "newer_docs_permalink" (replace .Page.Permalink $pageVersion $latest) }}
+            {{- /* provide a rel cannonical to follow for search engines */ -}}
+            <link rel="canonical" href='{{ .Page.Scratch.Get "newer_docs_permalink" }}' />
+        {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,19 @@
+{{- /* pull the data about currency from scratch, originally originating from `head-end.html` hook */ -}}
+{{- $not_current := .Page.Scratch.Get "docs_not_current" -}}
+{{- /* don't render a warning if it is current */ -}}
+{{- if $not_current -}}
+<div class="pageinfo olddocs">
+    {{- /* pull all the existing scratch to render the warning. */ -}}
+    {{- $this_version := .Page.Scratch.Get "docs_this_sections_version" -}}
+    {{- $section_version := .Page.Scratch.Get "docs_section_current_version" -}}
+    {{- $newer_docs_avail_version := .Page.Scratch.Get "newer_docs_avail_version" -}}
+    {{- $newer_docs_permalink := .Page.Scratch.Get "newer_docs_permalink" -}}
+    {{- /* render the message */ -}}
+    You are viewing documentation for version {{ $this_version }}. 
+    The most current version is {{ $section_version }}.
+    {{- /* Some situations will exist where a newer file doesn't exist, so only show if there is one */ -}}
+    {{- if $newer_docs_avail_version -}} 
+    &nbsp; This <a href="{{$newer_docs_permalink}}"> documentation is available for {{$newer_docs_avail_version}}</a>.
+    {{- end -}}
+</div>
+{{- end -}}

--- a/layouts/shortcodes/latest-redirect.html
+++ b/layouts/shortcodes/latest-redirect.html
@@ -1,0 +1,55 @@
+{{/* get the file name associated with the page */}}
+{{- $file := print .Page.File.Dir  -}}
+{{/* split by the seperator ("/") */}}
+{{- $parts := split $file "/" -}}
+{{/* this will grab the first part which is the section (aka product), e.g. `os` */}}
+{{- $url_section := index $parts 0 -}}
+{{/* grab the current version from the Hugo data file */}}
+{{- $versions := index $.Site.Data.versions.current $url_section -}}
+{{/* create the version string (e.g. `1.14.x`) */}}
+{{- $latest := print $versions.major "." $versions.minor ".x" -}}
+{{/* get the language (which is not part of the file name) */}}
+{{- $language := .Page.Language.Lang -}}
+
+<script>
+    {{/* JS IIFE to isolate variable scope */}}
+    (function() {
+        {{/* create an array */}}
+        var currentVersion = [];
+        var currentURLPrefix = "/{{$language}}/{{$url_section}}/{{$latest}}";
+        {{/* all the pages registered to the site */}}
+        {{ range .Site.AllPages }}
+            {{- /* break apart the page's permalink */ -}}
+            {{- $permalink_parts := split .RelPermalink "/" -}}
+            {{- /* this has the full URL including the language, so grab the language, section, and version */ -}}
+            {{- $docs_lang := index $permalink_parts 1 -}}
+            {{- $docs_section := index $permalink_parts 2 -}}
+            {{- $docs_version := index $permalink_parts 3 -}}
+            {{- /* if the page evaluated is the latest version, in the correct section, and correct language */ -}}
+            {{- if and (eq $docs_version $latest) (eq $url_section $docs_section) (eq .Language.Lang $docs_lang) -}}
+                {{- /* push it into an JS Array */ -}}
+                {{- /* remove the initial section (e.g. /en/os/1.14.x) */ -}}
+                currentVersion.push("{{ .RelPermalink }}".replace(currentURLPrefix,""));
+            {{ end }}
+        {{- end -}}
+        {{/* new `currentVersion` contains only the valid pages in the correct section/langauge/version */}}
+        var docs_location;
+        {{/* do we have a hash in the URL? */}}
+        if (window.location && window.location.hash) {
+            {/* get the hash portion and snip off the first character (will always be #) */}}
+            docs_location = window.location.hash.slice(1); 
+            {{/* does it have a trailing slash? If not, add one to match the Hugo output */}}
+            if (docs_location[docs_location.length-1] !== '/') { 
+                docs_location = docs_location + '/';
+            }
+            {{/* Is the passed URL fragment in the array? */}}
+            if (currentVersion.indexOf(docs_location) !== -1) {
+                {{/* reconstruct the URL with the latest version */}}
+                location.assign(currentURLPrefix + docs_location);
+            } else {
+                {{/* otherwise just go to the top of the current version */}}
+                location.assign(currentURLPrefix);
+            }
+        }
+    })();
+</script>

--- a/layouts/shortcodes/latest-redirect.html
+++ b/layouts/shortcodes/latest-redirect.html
@@ -36,7 +36,7 @@
         var docs_location;
         {{/* do we have a hash in the URL? */}}
         if (window.location && window.location.hash) {
-            {/* get the hash portion and snip off the first character (will always be #) */}}
+            {{/* get the hash portion and snip off the first character (will always be #) */}}
             docs_location = window.location.hash.slice(1); 
             {{/* does it have a trailing slash? If not, add one to match the Hugo output */}}
             if (docs_location[docs_location.length-1] !== '/') { 


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #191 

**Description of changes:**

This PR accomplishes three related things:
1. Provides a notice to users when they are browsing old documentation.

![Screenshot 2023-07-12 at 3 02 39 PM](https://github.com/bottlerocket-os/bottlerocket-project-website/assets/1152927/5c256ec9-c85e-4180-b67f-8a5849492ca4)

2. Provides logic to create evergreen links
3. Adds a `rel=canonical` html tag to previous version pages to prevent google from indexing old versions and never pointing to the newer versions.

---

This is a little bit complicated to implement with a static site but here is the flow:

1. The template hook `layouts/partials/hooks/head-end.html` does the primary logic to determine if the page is out-of-date. It does this by re-parsing the source file names and looking for a newer version based on the Site Data. It also adds the `rel=canonical` if required.

2. I overrode the the partial `layouts/partials/version-banner.html` which is used when you use subdomains for versioning (we don't use it here). This takes the information from `layouts/partials/hooks/head-end.html` and renders an HTML notice. 

3. I implemented a shortcode `layouts/shortcodes/latest-redirect.html` which converts data generated from Hugo into a javascript array in a script tag and then compares it to the `#` component of the URL, if it matches a valid piece of content from the most recent version, it does a JS location change (forward) to the newer content. The shortcode is only used now in `content/en/os/latest.markdown`. This means a URL like `https://bottlerocket.dev/en/os/latest/#/login/regaining-access/` would point to `https://bottlerocket.dev/en/os/1.14.x/login/regaining-access/` nor or, say,  `https://bottlerocket.dev/en/os/1.18.x/login/regaining-access/` in the future. If it doesn't match, it forwards the user to the top document in the latest documentation.

Note: Since this is a post page-load forward, SEO won't be passed, so these `/latest/#/...` links should be used sparingly, but they do accomplish the UX need. 

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
