### PR TITLE
levels the API driven docs with content in readme

### DIFF
--- a/content/en/os/1.14.x/concepts/api-driven/index.markdown
+++ b/content/en/os/1.14.x/concepts/api-driven/index.markdown
@@ -12,10 +12,12 @@ Additionally, administrative tasks like checking for updates and rebooting as we
 
 ## Accessing the API
 
-The Bottlerocket API is only accessible by containers running on the same host with specific SELinux labels.
+Bottlerocket API requests are made with HTTP requests over a Unix domain socket.
+The API is only accessible by containers running on the same host with specific SELinux labels.
 The API Unix domain socket is accessible by mounting; containers running on the host can access the API as long as they have both the correct SELinux labels and mount the socket.
 Both the Admin and Control containers have the requisite SELinux labels and socket pre-mounted.
 Because access to the API socket is through explicit mounts and SELinux labels there is no authentication required.
+Consequently, any remote access to the API necessitates an authenticated transport mechanism.
 
 ## API Client
 


### PR DESCRIPTION

**Issue number:**

Closes #194

**Description of changes:**

This changes adds a few missing pieces to the API documentation. 

These additions are needed to move the primary documentation for the API from the readme of bottlerocket-os/bottlerocket to [*/concepts/api-driven/](https://bottlerocket.dev/en/os/1.14.x/concepts/api-driven/) and not lose any missing info.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
