### PR TITLE
Sort package inventory for versions script

### DIFF
--- a/scripts/software-versions-inventory/software-versions-inventory.sh
+++ b/scripts/software-versions-inventory/software-versions-inventory.sh
@@ -6,7 +6,7 @@ printf "title: \"%s\"\n" $bottlerocket_release
 printf "type: \"docs\"\n"
 printf "description: \"Package Versions in Bottlerocket Release %s\"\n" $bottlerocket_release
 printf "packages:\n"
-for d in $(find $1/packages -maxdepth 1 -type d)
+for d in $(find $1/packages -maxdepth 1 -type d | sort)
 do
     if [ $d != $1/packages ]; then
         base=$(basename $d)


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

The software-versions-inventory.sh script gets a nicely formatted list of packages for each Bottlerocket version and renders it into a easily readable markdown table with a lot of good details. This table currently ends up listing the packages in whatever order the `find` command returns the package names from intrspecting the repo contents, which means it is a somewhat randomized list of packages that requires searching through if you are looking for a specific item.

This is a minor change to sort the results of the `find` command so that this table is always in alphabetical order, making it a little easier to find what you're looking for.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
