### PR TITLE
fix unintended version warning

### DIFF
--- a/content/en/os/_index.markdown
+++ b/content/en/os/_index.markdown
@@ -3,7 +3,7 @@ title="OS"
 type="docs"
 description="Documentation for the Bottlerocket operating system"
 body_class="suppress_section_listing"
-
+no_version_warning=true
 +++
 
 This section covers installing and using the Bottlerocket operating system[^1]. If you’re looking for information on building, contributing to, or learning about the inner workings of Bottlerocket, the [GitHub repo](https://github.com/bottlerocket-os/bottlerocket) has more information.

--- a/content/en/os/latest.markdown
+++ b/content/en/os/latest.markdown
@@ -2,6 +2,7 @@
 type="docs"
 title="Latest"
 toc_hide=true
+no_version_warning=true
 +++
 
 {{< latest-redirect >}}

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,7 +1,7 @@
 {{- /* pull the data about currency from scratch, originally originating from `head-end.html` hook */ -}}
 {{- $not_current := .Page.Scratch.Get "docs_not_current" -}}
 {{- /* don't render a warning if it is current */ -}}
-{{- if $not_current -}}
+{{- if and $not_current (ne .Params.no_version_warning true) -}}
 <div class="pageinfo olddocs">
     {{- /* pull all the existing scratch to render the warning. */ -}}
     {{- $this_version := .Page.Scratch.Get "docs_this_sections_version" -}}

--- a/layouts/shortcodes/subsections-list.html
+++ b/layouts/shortcodes/subsections-list.html
@@ -2,7 +2,9 @@
 <div class="section-index subsection-list">
     <div class="entry">
         {{ range (.Page.Pages).Reverse  }}
-            <h5><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h5>
+            {{- if (ne .Params.no_version_warning true) -}}
+                <h5><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h5>
+            {{- end -}}
         {{ end }}
     </div>
 </div>


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #212

**Description of changes:**

Adds an exception to page parameters that blocks version warnings on pages as needed.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
