### PR TITLE
adapts content for ecs-2 and 1.15

### DIFF
--- a/content/en/os/1.15.x/concepts/variants/index.markdown
+++ b/content/en/os/1.15.x/concepts/variants/index.markdown
@@ -65,6 +65,6 @@ A few examples:
 |aws-k8s-**1.24**-x86_64-1.12.0|aws-k8s-**1.25**-x86_64-1.12.0|✗|✓|The orchestrator version is part of the variant, so this is a migration.|
 |aws-k8s-**1.24**-x86_64-**1.12.0**|aws-k8s-**1.25**-x86_64-**1.13.0**|✗|✓|Both the Bottlerocket version and the variant are changing so this must be accomplished by a migration.|
 |aws-k8s-1.24-x86_64-1.13.0|aws-k8s-1.24-**nvidia**-x86_64-1.13.0|✗|✓|The flavor is part of the variant, so this change must be accomplished by a migration|
-|aws-**ecs-1**-x86_64-1.13.0|aws-**k8s-1.25**-x86_64-1.13.0|✗|✗|The orchestrator has changed. The cluster must be rebuilt.|
+|aws-**ecs-2**-x86_64-1.15.0|aws-**k8s-1.28**-x86_64-1.15.0|✗|✗|The orchestrator has changed. The cluster must be rebuilt.|
 
 If you are using a node replacement strategy, the distinction between migrating and updating is less important as any change is effectively a migration.

--- a/content/en/os/1.15.x/install/quickstart/aws/ecs/index.markdown
+++ b/content/en/os/1.15.x/install/quickstart/aws/ecs/index.markdown
@@ -105,7 +105,7 @@ export ECS_SUBNET_ID=$(aws ec2 describe-subnets \
    --region $AWS_REGION \
    --filter=Name=vpc-id,Values=$ECS_VPC_ID \
    | jq --raw-output '.Subnets[0] | {id: .SubnetId, public: .MapPublicIpOnLaunch, az: .AvailabilityZone} | .id')
-export BOTTLEROCKET_AMI_ID="resolve:ssm:/aws/service/bottlerocket/aws-ecs-1/x86_64/latest/image_id"
+export BOTTLEROCKET_AMI_ID="resolve:ssm:/aws/service/bottlerocket/aws-ecs-2/x86_64/latest/image_id"
 export ECS_INSTANCE_PROFILE_NAME=$(aws iam list-instance-profiles-for-role \
    --role-name $ECS_INSTANCE_ROLE_NAME \
    --query "InstanceProfiles[*].InstanceProfileName" \

--- a/content/en/os/1.15.x/install/quickstart/aws/host-containers/index.markdown
+++ b/content/en/os/1.15.x/install/quickstart/aws/host-containers/index.markdown
@@ -88,29 +88,11 @@ You should see something similar to the following:
   {{< tab header="Orchestrator:" disabled=true />}}
   {{< tab header="EKS" >}}
 [root@admin]# cat /.bottlerocket/rootfs/etc/os-release
-NAME=Bottlerocket
-ID=bottlerocket
-VERSION="1.12.0 (aws-k8s-1.25)"
-PRETTY_NAME="Bottlerocket OS 1.12.0 (aws-k8s-1.25)"
-VARIANT_ID=aws-k8s-1.25
-VERSION_ID=1.12.0
-BUILD_ID=6ef1139f
-HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
-SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
-BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
+{{< os-release-example orchestrator="k8s" build_id="6ef1139f" >}}
   {{< /tab >}}
   {{< tab header="ECS" >}}
 [root@admin]# cat /.bottlerocket/rootfs/etc/os-release
-NAME=Bottlerocket
-ID=bottlerocket
-VERSION="1.13.1 (aws-ecs-1)"
-PRETTY_NAME="Bottlerocket OS 1.13.1 (aws-ecs-1)"
-VARIANT_ID=aws-ecs-1
-VERSION_ID=1.13.1
-BUILD_ID=32e9bb46
-HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
-SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
-BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
+{{< os-release-example orchestrator="ecs" build_id="32e9bb46" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/data/versions/current.toml
+++ b/data/versions/current.toml
@@ -4,3 +4,7 @@
     patch = 0
     foldable_check_id = "#m-enos115x-check" 
     # this is the HTML ID of the sidebar hidden checkmark. There is a script that will auto open the correct menu item
+[k8s]
+    versions = ["1.23","1.24","1.25","1.26","1.27","1.28"]
+[ecs]
+    versions = ["1","2"]

--- a/layouts/shortcodes/diagram_variants.svg
+++ b/layouts/shortcodes/diagram_variants.svg
@@ -343,7 +343,7 @@ $(document).ready(function() {
          id="tspan6700"
          class="variant_label"
          x="274.08826"
-         y="57.853008">bottlerocket-aws-ecs-1-x86_64-{{ $version_current }}</tspan></text>
+         y="57.853008">bottlerocket-aws-ecs-2-x86_64-{{ $version_current }}</tspan></text>
     <circle
        class="dot"
        id="circle6706"

--- a/layouts/shortcodes/os-release-example.html
+++ b/layouts/shortcodes/os-release-example.html
@@ -1,0 +1,15 @@
+{{- $orchestrator := .Get "orchestrator" -}}
+{{- $version_array := index $.Site.Data.versions.current $orchestrator }}
+{{- $bottlerocket_version := print $.Site.Data.versions.current.os.major "." $.Site.Data.versions.current.os.minor "." $.Site.Data.versions.current.os.patch -}}
+{{- $orchestrator_version := index (last 1 $version_array.versions) 0 -}}
+{{- $build_id := .Get "build_id" -}}
+NAME=Bottlerocket
+ID=bottlerocket
+VERSION="{{ $bottlerocket_version }} (aws-{{ $orchestrator }}-{{ $orchestrator_version }})"
+PRETTY_NAME="Bottlerocket OS {{ $bottlerocket_version }} (aws-{{ $orchestrator }}-{{ $orchestrator_version }})"
+VARIANT_ID=aws-{{ $orchestrator }}-{{ $orchestrator_version }}
+VERSION_ID={{ $bottlerocket_version }}
+BUILD_ID={{ $build_id }}
+HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
+SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
+BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #198

**Description of changes:**
Adapts multiple pieces of content to use ECS-2 variant

- Modifies variant conceptual docs to use ecs-2 (`en/os/1.15.x/concepts/variants`)
- Updates the ssm parameter for ECS-2 on the quickstart (`en/os/1.15.x/install/quickstart/aws/ecs`)
- Adds k8s and ecs version info into current version data file
- Refactors the os-release example on the host containers documentation into a shortcode that will autoupdate
- Changes ECS version on SVG


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
