### PR TITLE
Adds `deprecation` to model for settings documentation DSL

### DIFF
--- a/METADOC-SETTING-DOCS-DSL.md
+++ b/METADOC-SETTING-DOCS-DSL.md
@@ -83,6 +83,7 @@ Will have the heading “Note” andis  rendered separately after the `descripti
 * `warning` (optional, [string](https://toml.io/en/v1.0.0#string), markdownified): Information that warns the reader of potentially dangerous outcomes.
 Will have the heading “Warning” and is rendered separately after the `description`
 * `accepted_values` (optional, [array](https://toml.io/en/v1.0.0#array) of [string](https://toml.io/en/v1.0.0#string), each string is markdownified): A representation of allowed values, typically for enums where there are specific allowable strings in a setting value.
+* `deprecated` (optional, [boolean](https://toml.io/en/v1.0.0#boolean)): If `true`, the setting will be marked as 'deprecated'
 * `name_override` (optional, [string](https://toml.io/en/v1.0.0#string)): In situations where a setting cannot be represented as a 3-element array, this string can override the textual and linking representation.
 For example, if you have a setting like `setting.foo.bar.<some index>.baz` , you can define the documentation under `bar-index-baz` and set `name_override` to `bar.<some index>.baz`  to make it render to the reader correctly.
 Hash links and references would still use  `bar-index-baz`.

--- a/layouts/partials/settings-setting-individual.html
+++ b/layouts/partials/settings-setting-individual.html
@@ -10,10 +10,15 @@
 {{- $setting_also_see := .Get "see" -}}
 {{- $setting_note := .Get "note" -}}
 {{- $tagHeadings := .Get "tagHeadings" -}}
-{{- $setting_accepted_values := .Get "accepted_values"}}
+{{- $setting_deprecated := .Get "deprecated" -}}
+{{- $setting_accepted_values := .Get "accepted_values" -}}
 <div class="setting-individual">
-    <h3 id="{{ $setting_id }}"><code>{{ $setting_full_name }}</code></h3>
-    <p>{{ $setting_description | markdownify }}</p>
+    <h3 id="{{ $setting_id }}"><code>{{ $setting_full_name }}</code>
+    {{ if $setting_deprecated }}
+        <span class="badge badge-secondary">Deprecated</span>
+    {{ end }}
+    </h3>
+    
 
     {{ if $setting_warning }}
         <div class="alert alert-warning" role="alert">

--- a/layouts/partials/settings_inner_page_link.html
+++ b/layouts/partials/settings_inner_page_link.html
@@ -2,4 +2,9 @@
 {{- $setting_link := .Get "link" }}
 {{- $setting_root := .Get "root" -}}
 {{- $values := .Get "values" }}
-<li><a href="#{{ $setting_link }}"><code>settings.{{$setting_root}}.{{ or $values.name_override $setting_name}}</code></a></li>
+<li>
+    <a href="#{{ $setting_link }}"><code>settings.{{$setting_root}}.{{ or $values.name_override $setting_name}}</code></a>
+    {{ if $values.deprecated }}
+        <span class="badge badge-secondary">Deprecated</span>
+    {{ end }}
+</li>

--- a/layouts/shortcodes/settings.html
+++ b/layouts/shortcodes/settings.html
@@ -20,6 +20,7 @@
             {{- $settingData.Set "id"  $settings_root -}}
             {{- $settingData.Set "name_override" .name_override -}}
             {{- $settingData.Set "prefix" "settings"}}
+            {{- $settingData.Set "deprecated" .deprecated -}}
             {{- if isset . "example" -}}
                 {{- $settingData.Set "has_example" true -}}
                 {{- $settingData.Set "example" .example -}}
@@ -113,6 +114,7 @@
                     {{- $settingData.Set "description" .description -}}
                     {{- $settingData.Set "id" $setting_name -}}
                     {{- $settingData.Set "default" .default -}}
+                    {{- $settingData.Set "deprecated" .deprecated -}}
                     {{- $settingData.Set "tags" .tags -}}
 
                     {{- $settingData.Set "warning" .warning -}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**
- Adds `deprecated` metadoc
- Adds template changes to display a "Deprecated" label on any setting with `deprecated` = `true`

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
