### PR TITLE
moves 1.14.x boostrap contaienrs into 1.15.x

### DIFF
--- a/content/en/os/1.15.x/api/settings/bootstrap-containers/_index.markdown
+++ b/content/en/os/1.15.x/api/settings/bootstrap-containers/_index.markdown
@@ -1,0 +1,8 @@
++++
+title="bootstrap-containers"
+type="docs"
+toc_hide=true
+description="Settings related to bootstrap containers (`settings.bootstrap-containers.*`)"
++++
+
+{{< settings >}}

--- a/content/en/os/1.15.x/concepts/bootstrap-containers/_index.markdown
+++ b/content/en/os/1.15.x/concepts/bootstrap-containers/_index.markdown
@@ -1,0 +1,89 @@
++++
+title = "Bootstrap Containers"
+type = "docs"
+description = "Setting up the host with containers that start during boot." 
++++
+
+Bootstrap containers are a form of {{< ver-ref project="os" page="/concepts/components" >}}host container{{< /ver-ref >}} that you can use to run critical software before the node connects to an orchestrator.
+They give you subsantial power to configure and modify the system in ways that would otherwise be [difficult or impossible](#use-cases).
+
+## Lifecycle
+
+When you define a bootstrap container using user-data or the Bottlerocket API, the following sequence occurs on next boot:
+
+- [`systemd`](https://systemd.io/) starts all of the bootstrap containers concurrently,
+- `systemd` will not move to the next [target](https://www.freedesktop.org/software/systemd/man/systemd.target.html) until all of the bootstrap containers start, run, and exit,
+- any bootstrap container configured with `{{< ver-ref project="os" page="/api/settings/bootstrap-containers#name_mode">}}mode=once{{< /ver-ref >}}` will change to `{{< ver-ref project="os" page="/api/settings/bootstrap-containers#name_mode">}}mode=off{{< /ver-ref >}}` once complete,
+- any bootstrap container set to `{{< ver-ref project="os" page="/api/settings/bootstrap-containers#name_essential">}}essential=true{{< /ver-ref >}}` that exits with an non-zero exit code halts the boot process,
+- unless stopped in the previous step, the boot process continues by loading the orchestrator agent ({{% ver-ref project="os" page="/concepts/components#container-and-orchestrator-support"%}} `kubelet` on `*-k8s-*` {{% /ver-ref %}} variants or the {{% ver-ref project="os" page="/concepts/components#ecs-variants" %}}ECS agent on `*-ecs-*`{{% /ver-ref %}} variants).
+
+### Examples
+
+{{< twocol
+    containerclass="td-max-width-on-larger-screens docs-figure"
+    rowclass="docs-figure" >}}
+    {{< twocol_inner colsplit="7" >}}
+        {{< bootstrap_containers_diagram example=1 >}}
+    {{</ twocol_inner >}}
+    {{% twocol_inner %}}
+This example shows four bootstrap containers (`B1`,`B2`,`B3`, and `B4`) starting.
+The start order of these containers is not sequential and could be in any order.
+Container `B2` runs the longest and the next stage of the boot does not proceed until it completes.
+    {{%/ twocol_inner %}}
+{{</ twocol >}}
+
+{{< twocol
+    containerclass="td-max-width-on-larger-screens docs-figure"
+    rowclass="docs-figure" >}}
+    {{< twocol_inner  colsplit="7" >}}
+        {{< bootstrap_containers_diagram example=2 >}}
+    {{</ twocol_inner >}}
+    {{% twocol_inner %}}
+This example is the same as the previous one except container `B2` is configured with {{< ver-ref project="os" page="/api/settings/bootstrap-containers#name_essential">}}`essential=true`{{< /ver-ref >}}.
+Container `B2` exits with a non-zero exit code and consquently the boot halts.
+    {{%/ twocol_inner %}}
+{{</ twocol >}}
+
+{{< twocol
+    containerclass="td-max-width-on-larger-screens docs-figure"
+    rowclass="docs-figure" >}}
+    {{< twocol_inner  colsplit="7" >}}
+        {{< bootstrap_containers_diagram example=3 >}}
+    {{</ twocol_inner >}}
+    {{% twocol_inner %}}
+This example is the same as the first except container `B4` is configured with {{< ver-ref project="os" page="/api/settings/bootstrap-containers#name_mode">}}`mode=once`{{< /ver-ref >}}.
+After all the bootstrap containers finish, Bottlerocket (via a `systemd` unit) updates container `B4`'s `mode` to `off`.
+    {{%/ twocol_inner %}}
+{{</ twocol >}}
+
+### Considerations
+
+As a consequence of this lifecycle, you should keep a few things in mind when using bootstrap containers:
+
+1. Bootstrap containers should be short-running and cleanly exit when complete otherwise the node will hang.
+2. Since `systemd` starts all the bootstrap containers concurrently, you cannot rely on a deterministic starting order.
+3. Bootstrap containers do not have access to the container orchestrator nor the rest of the cluster.
+4. Bootstrap containers should not modify critical configuration files (e.g. `/etc/`).
+
+## Capabilities and permissions
+
+Bootstrap containers sit somewhat between default host containers and `superpowered` host container permissions.
+They have access to the underlying host filesystem at `/.bottlerocket/` which contains the root filesystem (`/.bottlerocket/rootfs`).
+Additionally, bootstrap containers run with the {{< ver-ref project="os" page="/api/settings/oci-defaults#capabilities_sys-admin" >}}CAP_SYS_ADMIN capability{{< /ver-ref >}}, allowing for the creation of files, directories, and mounts accessible to the host (however the root filesystem remains {{< ver-ref project="os" page="/concepts/restricted-filesystem#immutable-filesystem" >}}immutable{{</ ver-ref>}}).
+You cannot elevate the permissions of bootstrap containers.
+
+## Use cases
+
+Bootstrap containers have a variety of uses.
+
+1. Configure large setting values.
+On many platforms there are [limits to the size of user-data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html) but you can use a bootstrap container to pass large values into `apiclient`.
+2. Conditionally halt boot.
+You can perform checks or evaluation of the system in a {{< ver-ref project="os" page="/api/settings/bootstrap-containers#name_essential" >}}bootstrap container with `essential` set to `true`{{< /ver-ref >}}.
+3. Apply settings you do not want to store in plaintext.
+In cases where you need to pass values that you would not want to store in plain-text on external systems (such as credentials), you can instead use a bootstrap container that sets the values via `apiclient`.
+4. Configure ephemeral disks. Since [bootstrap containers have access to `/.bottlerocket/rootfs/mnt`](#capabilities-and-permissions) and all bootstrap or `superpowered` host containers share this bind mount, you can configure ephemeral disks attached to your host in a bootstrap container and use it elsewhere.
+
+## Also see
+
+- {{< ver-ref project="os" page="/api/settings/bootstrap-containers">}} bootstrap-containers in the API Setting Reference{{< /ver-ref >}}

--- a/data/settings/1.15.x/bootstrap-containers.toml
+++ b/data/settings/1.15.x/bootstrap-containers.toml
@@ -1,0 +1,61 @@
+[[docs.ref.name_essential]]
+name_override = "<name>.essential"
+description = "If `essential` is set to `true` the bootstrap container will halt the boot process when it exits with a non-zero exit code."
+default = "`false`"
+accepted_values = [
+    "`true`",
+    "`false`"
+]
+see = [
+    ["[`settings.bootstrap-containers.<name>.source`](#name_source) for a full example with `settings.bootstrap-containers.<name>.essential`."],
+    ["The {{< ver-ref project=\"os\" page=\"/concepts/bootstrap-containers#lifecycle\" >}}bootstrap container lifecycle{{< /ver-ref >}} conceptual documentationion"]
+]
+
+
+[[docs.ref.name_mode]]
+name_override = "<name>.mode"
+description = """
+Specifies how (or if) a container starts at boot. 
+If you set the value to:
+
+* `"always"`, the container will start on every boot,
+* `"off"`, the container will not start at boot,
+* `"once"`, the container will start on the first boot but after exit, the `mode` changes to `off`. 
+"""
+accepted_values = [
+    "`\"always\"`",
+    "`\"off\"`",
+    "`\"once\"`"
+]
+see = [
+    ["[`settings.bootstrap-containers.<name>.source`](#name_source) for a full example with `settings.bootstrap-containers.<name>.mode`."],
+    ["The {{< ver-ref project=\"os\" page=\"/concepts/bootstrap-containers#lifecycle\" >}}bootstrap container lifecycle{{< /ver-ref >}} conceptual documentation"]
+
+]
+
+[[docs.ref.name_source]]
+name_override = "<name>.source"
+description = "Defines the URI for a container to run as a bootstrap container."
+[[docs.ref.name_user-data]]
+name_override = "<name>.user-data"
+description = """
+An optional field that allows you to pass arbitrary base64-encoded data to the bootstrap container.
+The data is avaliable to the bootstrap container at `/.bottlerocket/bootstrap-containers/<container>/user-data` or `/.bottlerocket/bootstrap-containers/current/user-data`.
+"""
+[[docs.ref.name_source.example]]
+direct_toml = """
+# Creates a bootstrap container called `mybootstrap`
+# It runs only one time and if exits with a non-zero code, will halt the boot process
+[settings.bootstrap-containers.mybootstrap]
+source = \"uri.to.container.in.oci-compatible-registry.example.com/foo:1.0.0"
+mode = "once"
+essential = true
+"""
+direct_shell = """
+# Creates a bootstrap container called `mybootstrap`
+# It runs only one time and if exits with a non-zero code, will halt the boot process
+apiclient set \\
+    bootstrap-containers.mybootstrap.source=\"uri.to.container.in.oci-compatible-registry.example.com/foo:1.0.0" \\
+    bootstrap-containers.mybootstrap.mode=\"once\" \\
+    bootstrap-containers.mybootstrap.mode=true
+"""


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #238 

**Description of changes:**
This completes the documentation for bootstrap container in 1.15.x.

Note: none of this is _new_ content but just adding the existing (and unchanged) content from 1.14.x docs (recently merged) to 1.15.x

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
