### PR TITLE
Sort patches in package version list

### DIFF
--- a/scripts/software-versions-inventory/software-versions-inventory.sh
+++ b/scripts/software-versions-inventory/software-versions-inventory.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+shopt -s nullglob
+
 bottlerocket_root=${1:?}
 bottlerocket_release=$(grep "version =" $bottlerocket_root/Release.toml | cut -d "=" -f 2 | tr -d '"')
 
@@ -21,12 +23,11 @@ do
         printf "%4s" " "
         printf "%s" "version: "
         printf "%s\n" "$version" | cut -d":" -f1
-        patch_count=`find $d -type f -name "*.patch" | wc -l`
-        if [ $patch_count -gt 0 ]; then
-            patches=`find $d -type f -name "*.patch"`
+        patches=( "$d"/*.patch )
+        if [[ ${#patches[@]} -gt 0 ]]; then
             printf "%4s" " "
             printf "%s\n" "patches:"
-            for patch in $patches
+            for patch in "${patches[@]}"
             do
                 patch_file=$(basename $patch)
                 printf "%6s" " "

--- a/scripts/software-versions-inventory/software-versions-inventory.sh
+++ b/scripts/software-versions-inventory/software-versions-inventory.sh
@@ -6,32 +6,30 @@ printf "title: \"%s\"\n" $bottlerocket_release
 printf "type: \"docs\"\n"
 printf "description: \"Package Versions in Bottlerocket Release %s\"\n" $bottlerocket_release
 printf "packages:\n"
-for d in $(find $1/packages -maxdepth 1 -type d | sort)
+for d in $(find $1/packages -mindepth 1 -maxdepth 1 -type d | sort)
 do
-    if [ $d != $1/packages ]; then
-        base=$(basename $d)
-        rpmspec -q --qf "%{Version}:" $d/$base.spec  --define="_cross_os _" --nodebuginfo --quiet &> /dev/null
+    base=$(basename $d)
+    rpmspec -q --qf "%{Version}:" $d/$base.spec  --define="_cross_os _" --nodebuginfo --quiet &> /dev/null
 
-        if [ $? -eq 0 ]; then
-            version=$(rpmspec -q --qf "%{Version}:" $d/$base.spec  --define="_cross_os _" --nodebuginfo)
+    if [ $? -eq 0 ]; then
+        version=$(rpmspec -q --qf "%{Version}:" $d/$base.spec  --define="_cross_os _" --nodebuginfo)
 
-            printf "%2s" " "
-            printf "%s\r\n" "- package: $base"
-            printf "%4s" " " 
-            printf "%s" "version: "
-            printf "%s\n" "$version" | cut -d":" -f1
-            patch_count=`find $d -type f -name "*.patch" | wc -l`
-            if [ $patch_count -gt 0 ]; then
-                patches=`find $d -type f -name "*.patch"`
-                printf "%4s" " "
-                printf "%s\n" "patches:"
-                for patch in $patches
-                do
-                    patch_file=$(basename $patch)
-                    printf "%6s" " " 
-                    printf "%s\n" "- \"$patch_file\""
-                done
-            fi
+        printf "%2s" " "
+        printf "%s\r\n" "- package: $base"
+        printf "%4s" " "
+        printf "%s" "version: "
+        printf "%s\n" "$version" | cut -d":" -f1
+        patch_count=`find $d -type f -name "*.patch" | wc -l`
+        if [ $patch_count -gt 0 ]; then
+            patches=`find $d -type f -name "*.patch"`
+            printf "%4s" " "
+            printf "%s\n" "patches:"
+            for patch in $patches
+            do
+                patch_file=$(basename $patch)
+                printf "%6s" " "
+                printf "%s\n" "- \"$patch_file\""
+            done
         fi
     fi
 done

--- a/scripts/software-versions-inventory/software-versions-inventory.sh
+++ b/scripts/software-versions-inventory/software-versions-inventory.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-bottlerocket_release=$(grep "version =" $1/Release.toml | cut -d "=" -f 2 | tr -d '"')
+bottlerocket_root=${1:?}
+bottlerocket_release=$(grep "version =" $bottlerocket_root/Release.toml | cut -d "=" -f 2 | tr -d '"')
+
 printf "%s\n" "---"
 printf "title: \"%s\"\n" $bottlerocket_release
 printf "type: \"docs\"\n"
 printf "description: \"Package Versions in Bottlerocket Release %s\"\n" $bottlerocket_release
 printf "packages:\n"
-for d in $(find $1/packages -mindepth 1 -maxdepth 1 -type d | sort)
+for d in $(find $bottlerocket_root/packages -mindepth 1 -maxdepth 1 -type d | sort)
 do
     base=$(basename $d)
     rpmspec -q --qf "%{Version}:" $d/$base.spec  --define="_cross_os _" --nodebuginfo --quiet &> /dev/null


### PR DESCRIPTION
**Issue number:** n/a

**Description of changes:**  Sort the patches listed in the [package version list](https://bottlerocket.dev/en/os/1.15.x/version-information/packages/1.15.0/). This makes it easier to follow a patch series since patches are grouped (e.g. kernel) or at least in the proper order (e.g. grub).

This does not yet regenerate any of the front matter for the published package version lists. While I'd like to do that eventually (at least for 1.15.x, unless there's opposition), there's another change I'd like to make first, and we'll only have to do that once.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
