### PR TITLE
All Settings Index

### DIFF
--- a/content/en/os/1.15.x/api/settings-index/_index.markdown
+++ b/content/en/os/1.15.x/api/settings-index/_index.markdown
@@ -1,0 +1,9 @@
++++
+title="Settings Index"
+type="docs"
+toc_hide=true
+description="Comprehesive list of all documented settings"
+hide_summary=true
++++
+
+{{< all-settings >}}

--- a/content/en/os/1.15.x/api/settings-list/_index.markdown
+++ b/content/en/os/1.15.x/api/settings-list/_index.markdown
@@ -1,7 +1,0 @@
-+++
-title="List of all settings"
-type="docs"
-toc_hide=true
-description="Foo bar"
-hide_summary=true
-+++

--- a/content/en/os/1.15.x/api/settings-list/_index.markdown
+++ b/content/en/os/1.15.x/api/settings-list/_index.markdown
@@ -1,0 +1,7 @@
++++
+title="List of all settings"
+type="docs"
+toc_hide=true
+description="Foo bar"
+hide_summary=true
++++

--- a/data/settings/1.15.x/oci-defaults.toml
+++ b/data/settings/1.15.x/oci-defaults.toml
@@ -358,7 +358,7 @@ see = [
     ["`CAP_MAC_OVERRIDE` on the [Linux `capabilities` manual page](https://man7.org/linux/man-pages/man7/capabilities.7.html)"]
 ]
 
-[[docs.ref.capabilities.net-admin]]
+[[docs.ref.capabilities_net-admin]]
 name_override = "capabilities_net-admin"
 tags = [ "capabilities" ]
 accepted_values = [

--- a/layouts/shortcodes/all-settings.html
+++ b/layouts/shortcodes/all-settings.html
@@ -1,0 +1,26 @@
+
+{{- /* get the path of the doc calling the shortcode */ -}}
+{{- $currentPath := print .Page.File.Dir -}}
+{{- /* break apart the path */ -}}
+{{- $parts := split $currentPath "/" -}}
+{{- /* 2nd (base 0) index has the version */ -}}
+{{- $version := index $parts 1 -}}
+
+{{- $settings_file := index $.Site.Data.settings $version -}}
+
+{{- range $settings_category, $settings_ref := $settings_file  -}}
+    <!-- <h2>settings.{{ $settings_category }}</h2> -->
+    {{- range $setting_name, $setting_details := $settings_ref.docs.ref -}} 
+        <code>
+            <a href="../settings/{{ $settings_category }}/#{{  $setting_name }}">
+                settings.{{ $settings_category }}
+                {{- if reflect.IsSlice $setting_details -}}
+                    {{- range $setting_details -}}
+                        .{{ ( or .name_override $setting_name ) }}
+                    {{- end -}}
+                {{- end -}}
+            </a>
+        </code>
+        <br />
+    {{- end -}}
+{{- end -}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**
Adds a page that provides a simple list of every bottlerocket setting for a given version.

Currently this page is not linked but generated (`/en/os/1.15.x/api/settings-index/`). At this point, it should be considered a debugging tool, as it can give the impression that it's all setting not just all _documented_ settings.

At a later point, once all settings are merged, it can be exposed as a link.

Additionally this PR contains a small fix to `oci-defaults` that fixes a markup error that obscured one setting.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
