### PR TITLE
Concept docs: Host containers 

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -128,6 +128,10 @@ $link-color: $light-link;
 #svg_admin_label tspan { @include svg-disabled-container-label; }
 
 @mixin svg-disabled-component { fill-opacity: 0.25; }
+.hide-control-and-admin-container {
+    #svg_control, #svg_control_label tspan, 
+    #svg_admin, #svg_admin_label tspan { display: none; }
+}
 .disabled-diagram-component-systemd { #svg_systemd { @include svg-disabled-component; } }
 .disabled-diagram-component-kernel { #svg_kernel { @include svg-disabled-component; } }
 .disabled-diagram-component-containerd-left { #svg_containerd_left  { @include svg-disabled-component; } }

--- a/content/en/os/1.15.x/concepts/bootstrap-containers/_index.markdown
+++ b/content/en/os/1.15.x/concepts/bootstrap-containers/_index.markdown
@@ -4,7 +4,7 @@ type = "docs"
 description = "Setting up the host with containers that start during boot." 
 +++
 
-Bootstrap containers are a form of {{< ver-ref project="os" page="/concepts/components" >}}host container{{< /ver-ref >}} that you can use to run critical software before the node connects to an orchestrator.
+Bootstrap containers are a form of {{< ver-ref project="os" page="/concepts/host-containers" >}}host container{{< /ver-ref >}} that you can use to run critical software before the node connects to an orchestrator.
 They give you substantial power to configure and modify the system in ways that would otherwise be [difficult or impossible](#use-cases).
 
 ## Lifecycle

--- a/content/en/os/1.15.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.15.x/concepts/host-containers/_index.markdown
@@ -20,12 +20,12 @@ Instead you manage the lifecycle of these containers by manipulating specific {{
 ## Built-in host containers
 
 Depending on the variant, Bottlerocket has two standard host containers: the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#interacting-with-a-bottlerocket-node-through-host-containers" >}}control container{{< /ver-ref >}} and the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#exploring-the-admin-container" >}}admin container{{< /ver-ref >}}.
-The control container provides a pathway to connect to and interact with the host as well as conveniently access the Bottlerocket API.
+The control container provides a pathway to connect ([via SMM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
 The control container also provides an entry point to the admin container.
 The admin container allows you to more deeply interact with the host as it mounts the root filesystem and has elevated privileges.
 
 The control and admin containers are not actually special: both are just host containers with specific privileges.
-Case in point, you can disable these containers as-needed and you can even fully replace the functionality of both the host and admins containers with your own host containers.
+Case in point, you can disable (and {{< ver-ref project="os" page="/login/regaining-access" >}}re-enable{{</ ver-ref >}}) these containers as-needed and you can even fully replace the functionality of both the host and admins containers with your own host containers.
 
 ## Properties of host containers
 
@@ -39,6 +39,7 @@ Bottlerocket has two parallel instances of `containerd`: one for your orchestrat
 
 All host containers automatically mount the API socket (`/run/api.sock`) and the API Client (`/usr/local/bin/apiclient`).
 This allows you to run API commands and manipulate Bottlerocket settings from within the host containers without explicitly mounting these resources.
+As a consequence, any user that can access a host container can change configurations which could effect the efficiency or stability of the node.
 
 ### Lifecycle & restarts
 
@@ -80,7 +81,7 @@ Examples:
 - {{< ver-ref project="os" page="/concepts/bootstrap-containers/" >}}Bootstrap Containers{{</ ver-ref >}}
 
 [^1]: The admin container has a special uses for user data. See the warning on {{< setting-reference setting="settings.host-containers.<container>.user-data" >}}{{</ setting-reference >}}
-[^2]: Paths for persistent storage and user data (`$HOST_CONTAINER_NAME` being the name of the host container):
+[^2]: Paths for persistent storage and user data (`<HOST_CONTAINER_NAME>` being the name of the host container):
 
-    - `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME` and `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME/user-data` 
+    - `/.bottlerocket/host-containers/<HOST_CONTAINER_NAME>` and `/.bottlerocket/host-containers/<HOST_CONTAINER_NAME>/user-data` 
     - `/.bottlerocket/host-containers/current` and `/.bottlerocket/host-containers/current/user-data`

--- a/content/en/os/1.15.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.15.x/concepts/host-containers/_index.markdown
@@ -4,9 +4,83 @@ type = "docs"
 description = "Special purpose, non-orchestrated containers for node management and administration" 
 +++
 
+Host containers are a special type of container you can use to manage and administer your Bottlerocket node.
+These containers are non-orchestrated, which means Kubernetes or ECS are unaware of these containers and cannot directly manage their lifecycle.
+Instead you manage the lifecycle of these containers by manipulating specific {{< ver-ref project="os" page="/api/settings/" >}}Bottlerocket settings{{< /ver-ref >}} with the {{< ver-ref project="os" page="/concepts/api-driven" >}}API{{< /ver-ref >}}.
+
 {{< twocol
     containerclass="td-max-width-on-larger-screens docs-figure"
     rowclass="docs-figure" >}}
     {{< twocol_inner >}}{{< components_diagram hide_admin_and_control=true >}}{{</ twocol_inner >}}
-    {{% twocol_inner colsplit="7" %}} This diagram represents the components of the `aws-k8s-*` variant. {{%/ twocol_inner %}}
+    {{% twocol_inner colsplit="7" %}} This diagram represents the components of the `aws-k8s-*` variant.
+    Note the "Host Containers" in the upper left.
+    {{%/ twocol_inner %}}
 {{</ twocol >}}
+
+## Built-in host containers
+
+Depending on the variant, Bottlerocket has two standard host containers: the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#interacting-with-a-bottlerocket-node-through-host-containers" >}}control container{{< /ver-ref >}} and the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#exploring-the-admin-container" >}}admin container{{< /ver-ref >}}.
+The control container provides a pathway to connect to and interact with the host as well as conveniently access the Bottlerocket API.
+The control container also provides an entry point to the admin container.
+The admin container allows you to more deeply interact with the host as it mounts the root filesystem and has elevated privileges.
+
+The control and admin containers are not actually special: both are just host containers with specific privileges.
+Case in point, you can disable these containers as-needed and you can even fully replace the functionality of both the host and admins containers with your own host containers.
+
+## Properties of host containers
+
+Host containers have a number of different properties from orchestrated containers.
+
+### Runtime
+
+Bottlerocket has two parallel instances of `containerd`: one for your orchestrated workloads and one for host containers.
+
+### API Access
+
+All host containers automatically mount the API socket (`/run/api.sock`) and the API Client (`/usr/local/bin/apiclient`).
+This allows you to run API commands and manipulate Bottlerocket settings from within the host containers without explicitly mounting these resources.
+
+### Lifecycle & restarts
+
+Host containers start and stop based on the value of their {{< setting-reference setting="settings.host-containers.<container>.enabled" >}}enabled{{</ setting-reference >}} setting.
+If a host container exits, Bottlerocket automatically restarts the container after 45 seconds.
+
+### Superpower
+
+Host containers can have high levels of privilege.
+See {{< setting-reference setting="settings.host-containers.<container>.superpowered" >}}{{</ setting-reference >}} for more details.
+
+### Updates
+
+Host containers do not update automatically.
+Updates only occur when you update the {{< setting-reference setting="settings.host-containers.<container>.source" >}}{{</ setting-reference >}}.
+
+### User data
+
+Distinct, but inspired by instance user data, host containers pass arbitrary[^1] base64-encoded data from the API into a file[^2].
+
+### Persistent storage
+
+All host containers have persistent storage that survive node reboots as well as container stop/start cycles[^2].
+
+## Use Cases
+
+When considering if you should use a host container, evaluate the specific properties of host containers and if you need to manage the lifecycle with your orchestrator.
+Generally, you should try to solve your problem with an orchestrated container and only turn to a host container for low-level use-cases.
+
+Examples:
+
+- The control container is a host container because it needs to be available early to give you access to the OS.
+- The admin container is a host container because it needs high levels of privilege and you may need it to debug when orchestration isn't working
+
+## Also See
+
+- `{{< ver-ref project="os" page="/api/settings/host-containers/" >}}host-containers{{</ ver-ref >}}` settings reference
+- `{{< ver-ref project="os" page="/api/settings/bootstrap-containers/" >}}boostrap-containers{{</ ver-ref >}}` setting reference
+- {{< ver-ref project="os" page="/concepts/bootstrap-containers/" >}}Bootstrap Containers{{</ ver-ref >}}
+
+[^1]: The admin container has a special uses for user data. See the warning on {{< setting-reference setting="settings.host-containers.<container>.user-data" >}}{{</ setting-reference >}}
+[^2]: Paths for persistent storage and user data (`$HOST_CONTAINER_NAME` being the name of the host container):
+
+    - `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME` and `/.bottlerocket/host-containers/$HOST_CONTAINER_NAME/user-data` 
+    - `/.bottlerocket/host-containers/current` and `/.bottlerocket/host-containers/current/user-data`

--- a/content/en/os/1.15.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.15.x/concepts/host-containers/_index.markdown
@@ -54,7 +54,7 @@ See {{< setting-reference setting="settings.host-containers.<container>.superpow
 ### Updates
 
 Host containers do not update automatically.
-Updates only occur when you update the {{< setting-reference setting="settings.host-containers.<container>.source" >}}{{</ setting-reference >}}.
+Updates only occur when you update the {{< setting-reference setting="settings.host-containers.<container>.source" >}}{{</ setting-reference >}} or when an {{< ver-ref project="os" page="/update/methods/in-place" >}}in-place update{{</ ver-ref >}} occurs.
 
 ### User data
 

--- a/content/en/os/1.15.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.15.x/concepts/host-containers/_index.markdown
@@ -1,0 +1,12 @@
++++
+title = "Host Containers"
+type = "docs"
+description = "Special purpose, non-orchestrated containers for node management and administration" 
++++
+
+{{< twocol
+    containerclass="td-max-width-on-larger-screens docs-figure"
+    rowclass="docs-figure" >}}
+    {{< twocol_inner >}}{{< components_diagram hide_admin_and_control=true >}}{{</ twocol_inner >}}
+    {{% twocol_inner colsplit="7" %}} This diagram represents the components of the `aws-k8s-*` variant. {{%/ twocol_inner %}}
+{{</ twocol >}}

--- a/layouts/shortcodes/components_diagram.html
+++ b/layouts/shortcodes/components_diagram.html
@@ -27,6 +27,7 @@
    <title id="{{ $aria_description_id }} ">{{ $aria_description }}</title>
    <g class="
     {{ if isset .Params "show_ecs" }} show_ecs {{ end }}
+    {{ if isset .Params "hide_admin_and_control"}} hide-control-and-admin-container {{ end }}
     {{ if isset .Params "disable_kubelet" }} disabled-diagram-component-kubelet {{ end }}
     {{ if isset .Params "disable_systemd" }} disabled-diagram-component-systemd {{ end }}
     {{ if isset .Params "disable_kernel" }} disabled-diagram-component-kernel {{ end }}

--- a/layouts/shortcodes/setting-reference.html
+++ b/layouts/shortcodes/setting-reference.html
@@ -1,0 +1,22 @@
+
+{{- $setting := or (.Get "setting") $.Inner -}}
+{{- $setting_parts := strings.Split $setting "." -}}
+{{- $ref := index $setting_parts 1 -}}
+{{- $current_path := print .Page.File.Dir -}}
+{{- $parts := split $current_path "/" -}}
+{{- $version := index $parts 1 -}}
+{{- $lang := print $.Page.Language -}}
+{{- $settings_at_version := index (index .Site.Data.settings $version) $ref }}
+{{- $page := . -}}
+{{- range $key, $value := $settings_at_version.docs.ref -}}
+    {{- range $value -}}
+        {{- $name := or (index . "name_override") $key }}
+        {{- $full_name := print "settings." $ref "." $name -}}
+        {{- if (eq $full_name $setting) -}}
+            {{- $path := print "/os/" $version "/api/settings/" $ref -}}
+            {{ $ref_link :=  relref $page (dict "path" $path "lang" $lang) }}
+            {{- $url := print "/"  $lang $path "#" $key -}}
+            <a href="{{ $url }}"><code>{{ or $.Inner $setting }}</code></a>
+        {{- end -}}
+    {{- end -}}
+{{- end -}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #254

**Description of changes:**
- Adds concept documentation for host containers
- Adds a short code to reference settings by name instead of by (relative) URL
- Changes reference on bootstrap containers concept documentation to point to this instead of the quickstart

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
