### PR TITLE
Adds page that outlines packages in each variant

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -285,6 +285,26 @@ $link-color: $light-link;
     #svg_control { @include svg-disabled-container; }
 }
 
+.package-by-variant-table{
+    overflow-x: auto;
+    thead, .variant-col {
+        white-space: nowrap;
+    }
+    th.angled {
+        height: 250px;
+        div {
+            transform: rotate(270deg);
+            width: 20px;
+        }
+    }
+    .dot-chart {
+        text-align: center;
+    }
+    .variant-col {
+        text-align: right;
+    }
+}
+
 .td-sidebar-nav .td-sidebar-link__page {
     font-family: $td-fonts-serif
 }

--- a/content/en/os/1.15.x/version-information/packages-by-variant/index.markdown
+++ b/content/en/os/1.15.x/version-information/packages-by-variant/index.markdown
@@ -1,0 +1,10 @@
++++
+title = "Packages by Variant"
+description = "Packages contained in each variant"
+type = "docs"
++++
+Legend:
+
+&#x2B24; Has package, &#x25EF; Does __not__ have package
+
+{{< packages-by-variant  >}}

--- a/layouts/shortcodes/packages-by-variant.html
+++ b/layouts/shortcodes/packages-by-variant.html
@@ -1,0 +1,45 @@
+{{- $version := "1.15.x" -}}
+{{- $variants := index .Site.Data.variants $version -}}
+{{- $packages := slice -}}
+{{- $variant_package_dicts := dict -}}
+{{- range $v_k, $v_v := $variants -}}
+    {{- range $v_v.package.metadata -}}
+        {{- range (index . "included-packages") -}}
+            {{- if (ne (collections.In $packages . ) true) -}}
+                {{- $packages = $packages | append . -}}
+            {{- end -}}
+            {{- $variant_package_dicts = merge $variant_package_dicts (dict $v_k (dict . true)) -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- $sorted_packages := sort $packages -}}
+
+<div class="package-by-variant-table">
+    <table class="table table-responsive table-striped package-by-variant-table">
+        <thead>
+            <tr>
+                <th scope="col">&nbsp;</th>
+                {{- range $package_name := (sort $packages) -}}
+                    <th scope="col" class="angled"><div>{{- $package_name -}}</div></th>
+                {{- end -}}
+            </tr>
+        </thead>
+        <tbody>
+            {{- range $variant_name, $variant_package_map := $variant_package_dicts -}}
+                <tr>
+                    <th scope="row" class="variant-col">{{- $variant_name -}}</th>
+                    {{- range $package_name := (sort $packages) -}}
+                        <td class="dot-chart">
+                            {{- if (index $variant_package_map $package_name) -}}
+                                <span aria-label="{{- $variant_name -}} has package {{- $package_name -}}"><span aria-hidden="true">&#x2B24;</span></span>
+                            {{- else -}}
+                                <span aria-label="{{- $variant_name -}} does not have {{- $package_name -}}"><span aria-hidden="true">&#x25EF;</span></span>
+                            {{- end -}}
+                        </td>
+                    {{- end -}}
+                </tr>
+            {{- end -}}
+        </tbody>
+    </table>
+</div>
+

--- a/layouts/shortcodes/packages-by-variant.html
+++ b/layouts/shortcodes/packages-by-variant.html
@@ -1,4 +1,8 @@
-{{- $version := "1.15.x" -}}
+{{- $currentPath := print .Page.File.Dir -}}
+{{- /* break apart the path */ -}}
+{{- $parts := split $currentPath "/" -}}
+{{- /* 2nd (base 0) index has the version */ -}}
+{{- $version := index $parts 1 -}}
 {{- $variants := index .Site.Data.variants $version -}}
 {{- $packages := slice -}}
 {{- $variant_package_dicts := dict -}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #36

**Description of changes:**

- adds a shortcode that has a chart that lists all variants and which packages they have
- Adds a page that hosts this shortcode
- Adds styles

One note: this is a responsive chart but it may exceed the width of narrow monitors so it does cause a contained horizontal table scroll. 

The page ends up producing a chart like this:
![Screenshot 2023-10-12 at 10 17 24 AM](https://github.com/bottlerocket-os/bottlerocket-project-website/assets/1152927/35e13d3e-644d-467f-bb28-52a82aaf7a3f)


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
