### PR TITLE
removes incomplete notice, adds reference for 1.14.x

### DIFF
--- a/content/en/os/1.14.x/api/settings/_index.markdown
+++ b/content/en/os/1.14.x/api/settings/_index.markdown
@@ -5,7 +5,7 @@ description="Individual settings avaliable for the `/settings` endpoint"
 +++
 
 {{% alert title="Note" color="warning" %}}
-This section is currently incomplete and represents a subset of available settings. Each setting group (i.e. `settings.*`) will be ported over as a unit. If the setting group you're interested in exists, consider that _group_ to be complete.
+This section is incomplete and represents a subset of available settings for 1.14.x. All settings are comprehensively documented starting with Bottlerocket 1.15.x in the [updated version of this section](/en/os/1.15.x/api/settings/).  
 
-See [Description of Settings](https://github.com/bottlerocket-os/bottlerocket#description-of-settings) on the Bottlerocket README for the definitive list until this notice is removed.
+See [__Description of Settings__](https://github.com/bottlerocket-os/bottlerocket/blob/v1.14.3/README.md#description-of-settings) on the Bottlerocket GitHub README tagged for 1.14.3 for the definitive list of Bottlerocket 1.14.x settings
 {{% /alert %}}

--- a/content/en/os/1.15.x/api/settings/_index.markdown
+++ b/content/en/os/1.15.x/api/settings/_index.markdown
@@ -3,9 +3,3 @@ title="Settings Reference"
 type="docs"
 description="Individual settings avaliable for the `/settings` endpoint"
 +++
-
-{{% alert title="Note" color="warning" %}}
-This section is currently incomplete and represents a subset of available settings. Each setting group (i.e. `settings.*`) will be ported over as a unit. If the setting group you're interested in exists, consider that _group_ to be complete.
-
-See [Description of Settings](https://github.com/bottlerocket-os/bottlerocket#description-of-settings) on the Bottlerocket README for the definitive list until this notice is removed.
-{{% /alert %}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #308 

**Description of changes:**

Removes messages about 1.15.x settings reference being incomplete. 
Updates message about 1.14.x being incomplete and points to the 1.14.3 tagged readme.


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
