### PR TITLE
Revert "fixes missed kerenl autoload"

### DIFF
--- a/data/settings/1.15.x/kernel.toml
+++ b/data/settings/1.15.x/kernel.toml
@@ -45,28 +45,6 @@ apiclient set settings.kernel.modules.sctp.allowed=false
 apiclient set settings.kernel.modules.udf.allowed=true
 """
 
-[[docs.ref.modules_autoload]]
-name_override = "modules.<name>.autoload"
-description = "If `true`, the kernel `<name>` module loads automatically on boot."
-note = """
-You must use this setting in conjuction with [`settings.kernel.modules.<name>.allowed`](#modules_allowed) on the same module.
-This ensures that the OS doesn't auto-load a blocked module. 
-"""
-accepted_values = [
-    "`true`",
-    "`false`"
-]
-[[docs.ref.modules_autoload.example]]
-direct_toml = """
-[settings.kernel.modules.ip_vs_lc]
-allowed = true
-autoload = true
-"""
-direct_shell = """
-apiclient set settings.kernel.modules.ip_vs_lc.allowed=true settings.kernel.modules.ip_vs_lc.autoload=true
-"""
-
-
 [[docs.ref.sysctl]]
 description = "Sets kernel parameters."
 note = "Add quotes (`\"`) around keys as they often contain dots (`.`) as well as around values."


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:** n/a

**Description of changes:**
```
This reverts commit b9924cba128b08b254d2f689848ed13c22149cd0.

The `kernel.modules.<name>.autoload` feature is not part of the 1.15.x branch. It will be released as part of 1.16.0 instead.
```

The missing feature in 1.15.0 was pointed out on the linked discussion https://github.com/bottlerocket-os/bottlerocket/discussions/3050 I closed prematurely, claiming it was part of 1.15.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
