### PR TITLE
Adding missed setting from after inital review

### DIFF
--- a/data/settings/1.15.x/kubernetes.toml
+++ b/data/settings/1.15.x/kubernetes.toml
@@ -617,3 +617,11 @@ For `aws-k8s-1.26` variants, which use the "external" cloud provider, a hostname
 see = [
     ["[`--hostname-override` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)"]
 ]
+
+[[docs.ref.seccomp-default]]
+description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
+default= "`false`"
+accepted_values = [
+    "`true`",
+    "`false`"
+]


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

Further review of version to version README and setting reference revealed skipped setting `seccomp-default`

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
