### PR TITLE
Adds  to 1.16.0 k8s docs

### DIFF
--- a/data/settings/1.16.x/kubernetes.toml
+++ b/data/settings/1.16.x/kubernetes.toml
@@ -617,3 +617,11 @@ For `aws-k8s-1.26` variants, which use the "external" cloud provider, a hostname
 see = [
     ["[`--hostname-override` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)"]
 ]
+
+[[docs.ref.seccomp-default]]
+description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
+default= "`false`"
+accepted_values = [
+    "`true`",
+    "`false`"
+]


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

See #335. Levelling a 1.15.x setting missed after import to 1.16.0 


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
