### PR TITLE
Move to Prod: `settings.kubernetes.seccomp-default`

### DIFF
--- a/data/settings/1.15.x/kernel.toml
+++ b/data/settings/1.15.x/kernel.toml
@@ -45,28 +45,6 @@ apiclient set settings.kernel.modules.sctp.allowed=false
 apiclient set settings.kernel.modules.udf.allowed=true
 """
 
-[[docs.ref.modules_autoload]]
-name_override = "modules.<name>.autoload"
-description = "If `true`, the kernel `<name>` module loads automatically on boot."
-note = """
-You must use this setting in conjuction with [`settings.kernel.modules.<name>.allowed`](#modules_allowed) on the same module.
-This ensures that the OS doesn't auto-load a blocked module. 
-"""
-accepted_values = [
-    "`true`",
-    "`false`"
-]
-[[docs.ref.modules_autoload.example]]
-direct_toml = """
-[settings.kernel.modules.ip_vs_lc]
-allowed = true
-autoload = true
-"""
-direct_shell = """
-apiclient set settings.kernel.modules.ip_vs_lc.allowed=true settings.kernel.modules.ip_vs_lc.autoload=true
-"""
-
-
 [[docs.ref.sysctl]]
 description = "Sets kernel parameters."
 note = "Add quotes (`\"`) around keys as they often contain dots (`.`) as well as around values."

--- a/data/settings/1.15.x/kubernetes.toml
+++ b/data/settings/1.15.x/kubernetes.toml
@@ -617,3 +617,11 @@ For `aws-k8s-1.26` variants, which use the "external" cloud provider, a hostname
 see = [
     ["[`--hostname-override` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)"]
 ]
+
+[[docs.ref.seccomp-default]]
+description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
+default= "`false`"
+accepted_values = [
+    "`true`",
+    "`false`"
+]


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

n/a - see #335

**Description of changes:**

Moves  missing `settings.kubernetes.seccomp-default` to prod.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
