### PR TITLE
adds community section for meetup, links, events, and discussion.

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -478,6 +478,26 @@ nav.foldable-nav .with-child, nav.foldable-nav .without-child {
     }
 }
 
+/* resources / links / events */
+.resource-list, #event_list {
+    h3 {
+        margin-bottom: 0;
+    }
+    margin-bottom: 2em;
+}
+#event_list {
+    &.future_only {
+        .event.past { 
+            display: none;
+        }
+    }
+    &.past_only {
+        .event.future {
+            display: none;
+        }
+    }
+    margin-top: 2em;
+}
 
 /* style bottom links */
 footer .text-links {

--- a/config.toml
+++ b/config.toml
@@ -85,3 +85,8 @@ ul_show = 1
   name = "FAQ"
   weight = 20
   url = "en/faq/"
+
+[[menu.main]]
+  name = "Community"
+  weight = 20
+  url = "en/community/"

--- a/content/en/community/_index.markdown
+++ b/content/en/community/_index.markdown
@@ -1,0 +1,6 @@
++++
+type="docs"
+title="Community"
++++
+
+Find out with other Bottlerocket users are doing by connecting through collaboration, stories, and interactions.

--- a/content/en/community/chat-discuss/index.markdown
+++ b/content/en/community/chat-discuss/index.markdown
@@ -1,0 +1,21 @@
++++
+title = "Chat & Discussion"
+type = "docs"
+description = "Avenues to talk to others interested in Bottlerocket"
++++
+
+## Slack
+
+You can find Bottlerocket developers and users on various Slack instances.
+
+- [Kubernetes Slack](https://communityinviter.com/apps/kubernetes/community) on channel `#eks`
+- [AWS Developer Slack](https://awsdevelopers.slack.com/join/shared_invite/zt-yryddays-C9fkWrmguDv0h2EEDzCqvw#/shared-invite/email) on channel `#bottlerocket`
+- [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) on channel `#wg-sp-os`
+
+## Forum
+
+The [Bottlerocket GitHub Discussions forum](https://github.com/bottlerocket-os/bottlerocket/discussions) is a great way to ask questions or get feedback from developers and other users.
+
+## Problems with Bottlerocket?
+
+If you think you found a bug or other problem with Bottlerocket, [file an issue](https://github.com/bottlerocket-os/bottlerocket/issues).

--- a/content/en/community/events/index.markdown
+++ b/content/en/community/events/index.markdown
@@ -1,0 +1,7 @@
++++
+title = "Events"
+type = "docs"
+description = "Upcoming events to find out more information about Bottlerocket" 
++++
+
+{{< events/loop >}}

--- a/content/en/community/links/index.markdown
+++ b/content/en/community/links/index.markdown
@@ -1,0 +1,7 @@
++++
+title = "Links & Resources"
+type = "docs"
+description = "Discover what others have written and said about Bottlerocket" 
++++
+
+{{< links/loop >}}

--- a/content/en/community/meetups/index.markdown
+++ b/content/en/community/meetups/index.markdown
@@ -1,0 +1,7 @@
++++
+title = "Meetups"
+type = "docs"
+description = "Join a group with others interested in Bottlerocket" 
++++
+
+{{< meetup/loop >}}

--- a/data/events/reinvent-2023.toml
+++ b/data/events/reinvent-2023.toml
@@ -1,0 +1,8 @@
+name = "Join us at re:Invent 2023"
+start_date = "2023-11-27"
+end_date = "2023-12-01"
+description = """
+Join Bottlerocket at re:Invent 2023! The Bottlerocket team is presenting [a workshop](https://hub.reinvent.awsevents.com/attendee-portal/catalog/?search=OPN202), 
+will be avaliable at [the Modern Applications zone in the expo hall](https://hub.reinvent.awsevents.com/attendee-portal/catalog/?search=ACT167), and [available to meet
+for conversations](https://github.com/bottlerocket-os/bottlerocket/discussions/3573).
+"""

--- a/data/links/cis-benchmark-blog.toml
+++ b/data/links/cis-benchmark-blog.toml
@@ -1,0 +1,8 @@
+date = "2023-02-02"
+title = "Validating Amazon EKS optimized Bottlerocket AMI against the CIS Benchmark"
+description = """
+This blog post describes how to validate Bottlerocket EKS variants using the CIS Benchmark.
+"""
+url = "https://aws.amazon.com/blogs/containers/validating-amazon-eks-optimized-bottlerocket-ami-against-the-cis-benchmark/"
+type = "blog"
+tags = [ "deep-dive" ]

--- a/data/links/fosdem-2023.toml
+++ b/data/links/fosdem-2023.toml
@@ -1,0 +1,8 @@
+date = "2023-02-23"
+title = "Bottlerocket OS - a container-optimized Linux"
+description = """
+A recording of the Bottlerocket talk at FOSDEM 23 which provides an introduction to the container optimized-space and an overview of Bottlerocket.
+"""
+url = "https://archive.fosdem.org/2023/schedule/event/container_bottlerocket_os/"
+type = "video"
+tags = [ "introduction" ]

--- a/data/links/opensearch-kubelet-fluent-bit.toml
+++ b/data/links/opensearch-kubelet-fluent-bit.toml
@@ -1,0 +1,8 @@
+date = "2022-07-20"
+title = "Using Fluent Bit and OpenSearch with Bottlerocket and Kubelet logs"
+description = """
+A walk through of capturing Bottlerocket's kubelet logs with Fluent Bit and sending them to OpenSearch. 
+"""
+url = "https://opensearch.org/blog/bottlerocket-k8s-fluent-bit/"
+type = "blog"
+tags = [ "walk-through" ]

--- a/data/links/sp-os-wg-video.toml
+++ b/data/links/sp-os-wg-video.toml
@@ -1,0 +1,8 @@
+date = "2023-10-03"
+title = "Bottlerocket at TAG Runtime Special Purpose Operating System Working Group (sp-os-wg)"
+description = """
+In this video, Bottlerocket is introduced to the CNCF TAG Runtime Special Purpose OS working group.
+"""
+url = "https://www.youtube.com/watch?v=zLP2JUR2xUg"
+type = "video"
+tags = [ "introduction" ]

--- a/data/links/target-au-gafoor.toml
+++ b/data/links/target-au-gafoor.toml
@@ -1,0 +1,8 @@
+date = "2023-10-10"
+title = "Reducing compute capacity by 40% on EKS with Bottlerocket and Karpenter"
+description = """
+A Kube.fm interview with Gazal Gafoor on how and why they used Bottlerocket with Karpenter at Target Australia.
+"""
+url = "https://kube.fm/gazal-eks-bottlerocket-karpenter"
+type = "video"
+tags = [ "interview" ]

--- a/data/meetups/community-meeting.toml
+++ b/data/meetups/community-meeting.toml
@@ -1,0 +1,7 @@
+title = "Official Bottlerocket Community Meeting Group"
+url = "https://www.meetup.com/bottlerocket-community/"
+type = "online"
+description = """
+Join this meetup for community meetings held every other Wednesday.
+This meetup features feedback sessions, release reviews, design reviews, as well as an interactive Q&A section.
+"""

--- a/layouts/partials/event.html
+++ b/layouts/partials/event.html
@@ -1,0 +1,9 @@
+<div class="event">
+    <h3 id="{{ .id }}"><a href="{{.event.url}}" target="#">{{ .event.name }}</a></h3>
+    <div>
+        <small>Date: <span class="start-date">{{.event.start_date}}</span> 
+        {{ if (isset .event "end_date") }} - <span class="end-date">{{.event.end_date}}</span>
+        {{end}} </small>
+    </div>
+    <p>{{ .event.description | markdownify }}</p>
+</div>

--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -1,0 +1,7 @@
+<div class="resource-list">
+    <h3 id="{{ .id }}"><a href="{{.link.url}}" target="#">{{ .link.title }}</a></h3>
+    <div>
+        <small>Date: {{ .link.date}} / Type: {{ .link.type}}</small>
+    </div>
+    <p>{{ .link.description | markdownify }}</p>
+</div>

--- a/layouts/partials/meetup.html
+++ b/layouts/partials/meetup.html
@@ -1,0 +1,7 @@
+<div class="resource-list">
+    <h3 id="{{ .id }}"><a href="{{.meetup.url}}" target="#">{{ .meetup.title }}</a></h3>
+    <div>
+        <small>Type: {{ .meetup.type}}</small>
+    </div>
+    <p>{{ .meetup.description | markdownify }}</p>
+</div>

--- a/layouts/shortcodes/events/loop.html
+++ b/layouts/shortcodes/events/loop.html
@@ -1,0 +1,65 @@
+<div class="btn-group" role="group" aria-label="Show Events">
+    <button id="future_only" type="button" class="btn btn-success select-buttons">Future only</button>
+    <button id="all" type="button" class="btn select-buttons">All</button>
+    <button id="past_only" type="button" class="btn select-buttons">Past only</button>
+</div>
+
+{{ $events_with_id := slice }}
+{{ range $k, $v := $.Site.Data.events }}
+    {{ $events_with_id = $events_with_id | append (dict "event" $v "id" $k "start_date" $v.start_date) }}
+{{ end }}
+
+{{ $events := sort $events_with_id "start_date" "desc" }}
+
+<div id="event_list" class="future_only">
+{{ range $events }}
+    {{- partial "event.html" . -}}
+{{ end }}
+</div>
+
+<script>
+    $(document).ready(function() {
+        var $eventList = $("#event_list"),
+            $events = $eventList.find('.event'),
+            $selectButtons = $('.select-buttons'),
+            selected_class = "btn-success",
+            past = "past",
+            future = "future",
+            only = "_only",
+            all = "all";
+
+        
+        
+
+        $events.each(function() {
+            var $thisEvent = $(this),
+                start_date = $thisEvent.find(".start-date").text(),
+                end_date = $thisEvent.find(".end-date").text(),
+                event_date = new Date((end_date ? end_date : start_date) + " 23:59:59");
+
+            if (event_date < new Date()) {
+                $thisEvent.addClass(past);
+            } else {
+                $thisEvent.addClass(future);
+            }
+        });
+
+        $selectButtons.click(function() {
+            var $this = $(this);
+            $selectButtons.removeClass(selected_class);
+
+            $this.addClass(selected_class);
+            
+            $eventList.removeClass(future_only +" "+all+" "+ past_only).addClass($this.attr("id"));
+        });
+
+        if ($eventList.find("."+future).length === 0) {
+            $("#" + future + only).attr("disabled", true).removeClass(selected_class);
+            $('#' + all).addClass(selected_class);
+            $eventList.removeClass(future + only).addClass(all);
+        } 
+        if ($eventList.find("."+past).length === 0) {
+            $("#" + past + only).attr("disabled", true).removeClass(selected_class);
+        }
+    });
+</script>

--- a/layouts/shortcodes/links/loop.html
+++ b/layouts/shortcodes/links/loop.html
@@ -1,0 +1,11 @@
+{{ $links_with_id := slice }}
+{{ range $k, $v := $.Site.Data.links }}
+    {{ $links_with_id = $links_with_id | append (dict "link" $v "id" $k "date" $v.date) }}
+{{ end }}
+
+{{ $links := sort $links_with_id "date" "desc" }}
+
+
+{{ range $links }}
+    {{- partial "link.html" . -}}
+{{ end }}

--- a/layouts/shortcodes/meetup/loop.html
+++ b/layouts/shortcodes/meetup/loop.html
@@ -1,0 +1,11 @@
+{{ $meetups_with_id := slice }}
+{{ range $k, $v := $.Site.Data.meetups }}
+    {{ $meetups_with_id = $meetups_with_id | append (dict "meetup" $v "id" $k "date" $v.date) }}
+{{ end }}
+
+{{ $meetups := sort $meetups_with_id "date" "desc" }}
+
+
+{{ range $meetups }}
+    {{- partial "meetup.html" . -}}
+{{ end }}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #184 

**Description of changes:**

This PR adds a "community" section to the top nav.

In the community section it contains:
- `/community/chat-discuss/` to promote the various slack channels the team frequents as well as the GitHub discussions forum
- `/community/events/` to show were Bottlerocket will be presenting or have a presence
- `/community/links/` to house links to resources about bottlrocket
- `/community/meetups/` to house links to meetup groups. Current it only has one entry, but can be easily expanded.

With the exception of the `chat-discuss` plain markdown page, they are driven by `/data/` files and use effectively the same logic and similar templates. They are designed to, in the future, allow for user-contributed information via pre populated PRs.

- `/data/events/` contains the TOML files for `/community/events/`
- `/data/links/`contains the TOML files for `/community/links`
- `/data/meetups` contains the TOML files for `/community/meetups`
 
Note: the events page requires some JS to sort Future/Past events in a reasonable way.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
