### PR TITLE
flip default value for `image-cleanup-enabled`

### DIFF
--- a/data/settings/1.14.x/ecs.toml
+++ b/data/settings/1.14.x/ecs.toml
@@ -156,7 +156,7 @@ tags = [
 
 [[docs.ref.image-cleanup-enabled]]
 description = "Enable automatic images clean up after the tasks have been removed."
-default = "`false`"
+default = "`true`"
 see = [
     ["`ECS_DISABLE_IMAGE_CLEANUP` in the [ECS Agent Environment Variables](https://github.com/aws/amazon-ecs-agent/blob/master/README.md#environment-variables)"]
 ]

--- a/data/settings/1.15.x/ecs.toml
+++ b/data/settings/1.15.x/ecs.toml
@@ -156,7 +156,7 @@ tags = [
 
 [[docs.ref.image-cleanup-enabled]]
 description = "Enable automatic images clean up after the tasks have been removed."
-default = "`false`"
+default = "`true`"
 see = [
     ["`ECS_DISABLE_IMAGE_CLEANUP` in the [ECS Agent Environment Variables](https://github.com/aws/amazon-ecs-agent/blob/master/README.md#environment-variables)"]
 ]

--- a/data/settings/1.16.x/ecs.toml
+++ b/data/settings/1.16.x/ecs.toml
@@ -156,7 +156,7 @@ tags = [
 
 [[docs.ref.image-cleanup-enabled]]
 description = "Enable automatic images clean up after the tasks have been removed."
-default = "`false`"
+default = "`true`"
 see = [
     ["`ECS_DISABLE_IMAGE_CLEANUP` in the [ECS Agent Environment Variables](https://github.com/aws/amazon-ecs-agent/blob/master/README.md#environment-variables)"]
 ]


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #357

**Description of changes:**

Flips the default value for `settings.ecs.image-cleanup-enabled` to the correct value across all documented versions.


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
