### PR TITLE
Fixes misleading MOTD example.

### DIFF
--- a/data/settings/1.14.x/motd.toml
+++ b/data/settings/1.14.x/motd.toml
@@ -2,4 +2,4 @@ top_level= true
 [[docs.ref]]
 description= "Changes the message of the day by writing out value to `/etc/motd`. Useful, low-risk way to try out the API."
 [[docs.ref.example]]
-value = "\"This is a mesage of the day. It will be displayed when someone logs into the control container!\""
+value = "\"This is a mesage of the day.\""

--- a/data/settings/1.15.x/motd.toml
+++ b/data/settings/1.15.x/motd.toml
@@ -2,4 +2,4 @@ top_level= true
 [[docs.ref]]
 description= "Changes the message of the day by writing out value to `/etc/motd`. Useful, low-risk way to try out the API."
 [[docs.ref.example]]
-value = "\"This is a mesage of the day. It will be displayed when someone logs into the control container!\""
+value = "\"This is a mesage of the day.\""

--- a/data/settings/1.16.x/motd.toml
+++ b/data/settings/1.16.x/motd.toml
@@ -2,4 +2,4 @@ top_level= true
 [[docs.ref]]
 description= "Changes the message of the day by writing out value to `/etc/motd`. Useful, low-risk way to try out the API."
 [[docs.ref.example]]
-value = "\"This is a mesage of the day. It will be displayed when someone logs into the control container!\""
+value = "\"This is a mesage of the day.\""


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

The text in the example indicates that the motd will show up in the control container. That's not the case.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
