### PR TITLE
Move to Prod: Setting reference index and new for x.x.x

### DIFF
--- a/content/en/os/1.15.x/api/settings-index/_index.markdown
+++ b/content/en/os/1.15.x/api/settings-index/_index.markdown
@@ -1,9 +1,7 @@
 +++
 title="Settings Index"
 type="docs"
-toc_hide=true
 description="Comprehesive list of all documented settings"
-hide_summary=true
 +++
 
 {{< all-settings >}}

--- a/content/en/os/1.16.x/api/settings-index/_index.markdown
+++ b/content/en/os/1.16.x/api/settings-index/_index.markdown
@@ -1,9 +1,7 @@
 +++
 title="Settings Index"
 type="docs"
-toc_hide=true
 description="Comprehesive list of all documented settings"
-hide_summary=true
 +++
 
-{{< all-settings >}}
+{{< all-settings new_badge=true >}}

--- a/data/versions/current.toml
+++ b/data/versions/current.toml
@@ -1,7 +1,7 @@
 [os]
     major = 1
     minor = 16
-    patch = 0
+    patch = 1
     foldable_check_id = "#m-enos116x-check" 
     # this is the HTML ID of the sidebar hidden checkmark. There is a script that will auto open the correct menu item
 [k8s]

--- a/layouts/partials/setting-list-item.html
+++ b/layouts/partials/setting-list-item.html
@@ -1,0 +1,14 @@
+{{ $url := "" }}
+{{ if .setting_name }}
+    {{ $url = printf "../settings/%s/#%s" .settings_category .setting_name }}
+{{ else }}
+    {{ $url = printf "../settings/%s/#%s" .settings_category .setting_name }}
+{{ end }}
+<code>
+    <a href="{{ $url }}">
+        settings.{{ .settings_category }}{{ if .setting_name }}.{{ ( or .name_override .setting_name ) }} {{ end }}
+    </a>
+</code>
+{{ if .new }}
+<span class="badge badge-secondary">New for {{ .new }}</span>
+{{ end }}

--- a/layouts/shortcodes/all-settings.html
+++ b/layouts/shortcodes/all-settings.html
@@ -1,26 +1,55 @@
+{{- $current_version := index (split .Page.File "/") 1  -}}
+{{- $all_versions := slice  -}}
+{{- $current_version_index := -1  -}}
+{{- $new_badge := .Get "new_badge" }}
 
-{{- /* get the path of the doc calling the shortcode */ -}}
-{{- $currentPath := print .Page.File.Dir -}}
-{{- /* break apart the path */ -}}
-{{- $parts := split $currentPath "/" -}}
-{{- /* 2nd (base 0) index has the version */ -}}
-{{- $version := index $parts 1 -}}
+{{- range (where .Site.Sections "Name" "OS")  -}}
+  {{- range $k, $v := .Sections  -}}
+    {{- if (eq $v.File.ContentBaseName $current_version)  -}}
+        {{- $current_version_index = $k  -}}
+    {{- end  -}}
+    {{- $all_versions = $all_versions | append $v.File.ContentBaseName  -}}
+  {{- end  -}}
+{{- end  -}}
 
-{{- $settings_file := index $.Site.Data.settings $version -}}
+{{- $old_version := index $all_versions (math.Sub $current_version_index 1) -}}
 
-{{- range $settings_category, $settings_ref := $settings_file  -}}
-    <!-- <h2>settings.{{ $settings_category }}</h2> -->
+<br />
+
+{{- $settings_file_new := index $.Site.Data.settings $current_version -}}
+{{- $settings_file_old := index $.Site.Data.settings $old_version -}}
+
+{{- range $settings_category, $settings_ref := $settings_file_new -}}
     {{- range $setting_name, $setting_details := $settings_ref.docs.ref -}} 
-        <code>
-            <a href="../settings/{{ $settings_category }}/#{{  $setting_name }}">
-                settings.{{ $settings_category }}
-                {{- if reflect.IsSlice $setting_details -}}
-                    {{- range $setting_details -}}
-                        .{{ ( or .name_override $setting_name ) }}
-                    {{- end -}}
+    {{- $setting_info := dict -}}
+        {{- if reflect.IsSlice $setting_details -}}
+            {{- range $setting_details -}}
+                {{- $setting_info = merge $setting_info (
+                    dict    "setting_name" $setting_name
+                            "settings_category" $settings_category
+                            "name_override" .name_override
+                )  -}}
+            
+                {{- $old_category := index $settings_file_old $settings_category  -}} 
+                {{- if (eq $new_badge true) -}}
+                    {{- if isset $old_category "docs" -}}
+                        {{- $old_setting := index $old_category.docs.ref $setting_name  -}}
+                        {{- if not (isset (index (index $old_category "docs") "ref") $setting_name)  -}}
+                            {{- $setting_info = merge $setting_info (dict "new" (string $current_version))  -}}
+                        {{- end  -}}
+                    {{- else  -}}
+                        {{- $setting_info = merge $setting_info (dict "new" (string $current_version))  -}}
+                    {{- end  -}}
                 {{- end -}}
-            </a>
-        </code>
-        <br />
+            {{- end -}}
+        {{- else -}}
+            {{- $setting_info = merge $setting_info (
+                dict    "setting_name" $setting_name
+                        "settings_category" $settings_category
+                        "name_override" .name_override
+            )  -}}
+        {{- end -}}
+
+        {{ partial "setting-list-item.html" $setting_info }}<br />
     {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

Moves the full index of settings to prod along side a "new for x.x.x" badge


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
