### PR TITLE
Improvement to docs for place updates using SSM and workload draining

### DIFF
--- a/content/en/os/1.16.x/update/methods/in-place/index.markdown
+++ b/content/en/os/1.16.x/update/methods/in-place/index.markdown
@@ -79,7 +79,7 @@ Brupop installation via the released YAML file is covered in the [Brupop documen
 
 If your Bottlerocket nodes are registered with AWS Systems Manager (SSM), it may be convenient for you to use SSM Command Documents to update your Bottlerocket nodes.
 
-**Important:** when using the SSM instructions below to update Bottlerocket nodes, workloads are _not_ be drained from the node before rebooting the node (unlike when using Brupop, for example).
+**Important:** when using the SSM instructions below to update Bottlerocket nodes, workloads will _not_ be drained from the node before rebooting the node, causing interruptions to the workloads (unlike when using Brupop, for example).
 
 ### SSM Command Document Method
 


### PR DESCRIPTION
"workloads are not be drained from the node" could be interpreted as "workloads are not (to) be drained from the node" instead of "workloads will not be drained from the node".