### PR TITLE
adds functionlity that hides single-entry lists in the menu

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -492,6 +492,16 @@ footer .text-links {
     }
 }
 
+.suppress-additional-index {
+    .section-index + .section-index {
+        display: none;
+    }
+}
+
+nav.foldable-nav .with-child.depad {
+    padding-left: 0;
+}
+
 /* old docs notice */
 .pageinfo.olddocs {
     margin-left: 0;

--- a/content/en/os/1.16.x/install/_index.markdown
+++ b/content/en/os/1.16.x/install/_index.markdown
@@ -3,4 +3,10 @@ title="Install"
 type="docs"
 description="How to install Bottlerocket"
 weight=50
+body_class="suppress-additional-index"
 +++
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" >}}
+
+### AWS Quickstart Install Guides
+
+{{< redirect-list actual="/os/%s/install/quickstart/aws/" >}}

--- a/content/en/os/1.16.x/install/quickstart/aws/ecs/index.markdown
+++ b/content/en/os/1.16.x/install/quickstart/aws/ecs/index.markdown
@@ -4,6 +4,11 @@ type="docs"
 description="How to get started with Bottlerocket on Amazon ECS"
 +++
 
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" depad="true" >}}
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/aws/" depad="true" >}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/">}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/aws/">}}
+
 In this quickstart, we use a number of techniques/tools like `jq` and environment variables to make the quickstart experience as simple and straightforward as possible.
 These tools are not absolutely necessary to use Bottlerocket on ECS.
 

--- a/content/en/os/1.16.x/install/quickstart/aws/host-containers/index.markdown
+++ b/content/en/os/1.16.x/install/quickstart/aws/host-containers/index.markdown
@@ -4,6 +4,12 @@ type="docs"
 description="How to interact with a Bottlerocket node through Host Containers"
 +++
 
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" depad="true" >}}
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/aws/" depad="true" >}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/">}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/aws/">}}
+
+
 ## Prerequisites
 
 - An AWS EC2 Instance ID (begins with `i-`) of a Bottlerocket instance

--- a/content/en/os/1.16.x/install/quickstart/aws/k8s/index.markdown
+++ b/content/en/os/1.16.x/install/quickstart/aws/k8s/index.markdown
@@ -4,6 +4,12 @@ type="docs"
 description="How to get started with Bottlerocket on Amazon EKS"
 +++
 
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" depad="true" >}}
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/aws/" depad="true" >}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/">}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/aws/">}}
+
+
 ## Prerequisites
 
 In order to set up a Bottlerocket cluster on EKS, you will need the latest versions of the following tools installed:

--- a/layouts/shortcodes/breadcrumb-remove.html
+++ b/layouts/shortcodes/breadcrumb-remove.html
@@ -1,0 +1,10 @@
+{{ $link_url := .Get "link_url" }}
+{{ $pathParts := split .Page.File.Path "/" }}
+{{ $full_link_url := fmt.Printf $link_url (index $pathParts 1)}}
+
+<script>
+    $(document).ready(function() {
+        var $crumb_link = $('.td-breadcrumbs a[href$="{{ $full_link_url }}"]');
+        $crumb_link.parent().hide();
+    });
+</script>

--- a/layouts/shortcodes/hide-and-re-highlight-menu.html
+++ b/layouts/shortcodes/hide-and-re-highlight-menu.html
@@ -1,0 +1,18 @@
+{{ $link_url := .Get "link_url" }}
+{{ $depad := eq (.Get "depad") "true" }}
+{{ $pathParts := split .Page.File.Path "/" }}
+{{ $full_link_url := fmt.Printf $link_url (index $pathParts 1)}}
+
+<script>
+    $(document).ready(function() {
+        var $sidebar_link = $('.td-sidebar a[href="{{ $full_link_url }}"]');
+        var $depad = {{ $depad }};
+
+        if ($depad) {
+           $sidebar_link.parent().parent().addClass('depad');
+        }
+
+        $sidebar_link.parent().hide();
+    });
+    
+</script>

--- a/layouts/shortcodes/redirect-list.html
+++ b/layouts/shortcodes/redirect-list.html
@@ -1,0 +1,5 @@
+{{ $actual := .Get "actual" }}
+{{ $pathParts := split .Page.File.Path "/" }}
+{{ with .Site.GetPage (fmt.Printf $actual (index $pathParts 1) )}}
+    {{ partial "section-index.html" .Page }}
+{{ end }}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #85

**Description of changes:**

This fixes #85 by adding 3 shortcodes:

- `{{ redirect-list }}` that allows injection of another section's list
- `{{ hide-and-re-highlight-menu }}` that hides portion of the nav menu based on parameters
- `{{ breadcrumb-remove }}` that hides portions of the bread crumbs based on parameters

Additionally, it adds these shortcodes to the pages under `Install`.

This results in a menu that skips over the single-entry `Quickstarts` and `AWS` sections and retains the same URLs.

![Screenshot 2023-12-14 at 9 50 16 AM](https://github.com/bottlerocket-os/bottlerocket-project-website/assets/1152927/b4923e8e-3f82-4c0f-9967-b5fc76e43cb2)


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
