### PR TITLE
port in the quickstart menu collapse snippets from 1.16.x

### DIFF
--- a/content/en/os/1.17.x/install/_index.markdown
+++ b/content/en/os/1.17.x/install/_index.markdown
@@ -3,4 +3,10 @@ title="Install"
 type="docs"
 description="How to install Bottlerocket"
 weight=50
+body_class="suppress-additional-index"
 +++
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" >}}
+
+### AWS Quickstart Install Guides
+
+{{< redirect-list actual="/os/%s/install/quickstart/aws/" >}}

--- a/content/en/os/1.17.x/install/quickstart/aws/ecs/index.markdown
+++ b/content/en/os/1.17.x/install/quickstart/aws/ecs/index.markdown
@@ -4,6 +4,11 @@ type="docs"
 description="How to get started with Bottlerocket on Amazon ECS"
 +++
 
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" depad="true" >}}
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/aws/" depad="true" >}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/">}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/aws/">}}
+
 In this quickstart, we use a number of techniques/tools like `jq` and environment variables to make the quickstart experience as simple and straightforward as possible.
 These tools are not absolutely necessary to use Bottlerocket on ECS.
 

--- a/content/en/os/1.17.x/install/quickstart/aws/host-containers/index.markdown
+++ b/content/en/os/1.17.x/install/quickstart/aws/host-containers/index.markdown
@@ -4,6 +4,11 @@ type="docs"
 description="How to interact with a Bottlerocket node through Host Containers"
 +++
 
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" depad="true" >}}
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/aws/" depad="true" >}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/">}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/aws/">}}
+
 ## Prerequisites
 
 - An AWS EC2 Instance ID (begins with `i-`) of a Bottlerocket instance

--- a/content/en/os/1.17.x/install/quickstart/aws/k8s/index.markdown
+++ b/content/en/os/1.17.x/install/quickstart/aws/k8s/index.markdown
@@ -4,6 +4,11 @@ type="docs"
 description="How to get started with Bottlerocket on Amazon EKS"
 +++
 
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/" depad="true" >}}
+{{< hide-and-re-highlight-menu link_url="/en/os/%s/install/quickstart/aws/" depad="true" >}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/">}}
+{{< breadcrumb-remove link_url="/en/os/%s/install/quickstart/aws/">}}
+
 ## Prerequisites
 
 In order to set up a Bottlerocket cluster on EKS, you will need the latest versions of the following tools installed:


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #85

**Description of changes:**

This adds the snippets to handle a collapsable menu on 1.17.x docs branch. No new code or content here, just pulling forward changes made from 1.16.x to 1.17.x


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
