### PR TITLE
Fixes issue with bolding on sidebar menu

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -309,8 +309,14 @@ $link-color: $light-link;
     }
 }
 
+input:checked + label a.td-sidebar-link__page {
+    font-weight: 600;
+}
+
+.td-sidebar-nav .td-sidebar-link__section,
 .td-sidebar-nav .td-sidebar-link__page {
-    font-family: $td-fonts-serif
+    //font-family: $td-fonts-serif
+    font-weight: 300;
 }
 
 .td-sidebar-nav__section-title,


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #348

**Description of changes:**
Adds new CSS to fix bolding.

**Note**: This is really patching over an issue with the upstream template. For some reason some "pages" are being rendered as "sections" (e.g. pages with children) by sidebar template in Docsy. Our docsy version is based on Bootstrap 4 and the current release of Docsy uses Boostrap 5 but it's unclear if updating the template would _solve_ the issue here as the code that generates the sidebar between our version and the most recent seems to be the same. I suspect it's some lurking corner case interaction between our customizations and a subtle bug upstream. Regardless, this patch seems to solve it the issue but it may become irrelevant (or worse) if we ever update.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
