### PR TITLE
Add a current version box to documentation homepage.

### DIFF
--- a/content/en/_index.markdown
+++ b/content/en/_index.markdown
@@ -3,6 +3,8 @@ type="docs"
 title="Documentation"
 +++
 
+{{< current-full-version >}}
+
 You may be familiar with general purpose Linux distributions like Ubuntu, Fedora, or Amazon Linux.
 With these Linux distributions, you can run a variety of workloads, setup in a variety of ways.
 While Bottlerocket is also a Linux distribution, Bottlerocket stands in stark contrast to general purpose distributions by being specifically optimized to host containers and interoperate directly with container orchestrators such as Kubernetes or ECS.

--- a/data/project_long_names.toml
+++ b/data/project_long_names.toml
@@ -1,0 +1,2 @@
+os = "Bottlerocket OS"
+brupop = "Bottlerocket Update Operator"

--- a/data/repos/os.toml
+++ b/data/repos/os.toml
@@ -1,0 +1,3 @@
+github = "https://github.com/bottlerocket-os/bottlerocket"
+path_prefix = "/tree/develop"
+github_issue_url = "https://github.com/bottlerocket-os/bottlerocket/issues/new/choose"

--- a/layouts/shortcodes/current-full-version.html
+++ b/layouts/shortcodes/current-full-version.html
@@ -1,0 +1,8 @@
+{{- $project_short := .Get "project" | default "os" -}}
+{{- $repo_metadata := index $.Site.Data.repos $project_short -}}
+{{- $full_version := print $.Site.Data.versions.current.os.major "." $.Site.Data.versions.current.os.minor "." $.Site.Data.versions.current.os.patch -}}
+<div class="card border-success mb-3">
+    <div class="card-body">
+        The most recent release of {{ index $.Site.Data.project_long_names $project_short }} is <strong>{{ $full_version }}</strong> (<a href="{{ $repo_metadata.github }}/releases/tag/v{{ $full_version }}">Release Notes</a>).
+    </div>
+</div>


### PR DESCRIPTION
**Issue number:**

Closes #369

**Description of changes:**

- adds shortcode for displaying current version and link to github release
- Adds metadata file that connects website 'project' section short forms to longer forms
- Adds current version shortcode to `/en/`


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
