### PR TITLE
fix SSM typo in concepts on 1.15.x to 1.19.x

### DIFF
--- a/content/en/os/1.15.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.15.x/concepts/host-containers/_index.markdown
@@ -20,7 +20,7 @@ Instead you manage the lifecycle of these containers by manipulating specific {{
 ## Built-in host containers
 
 Depending on the variant, Bottlerocket has two standard host containers: the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#interacting-with-a-bottlerocket-node-through-host-containers" >}}control container{{< /ver-ref >}} and the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#exploring-the-admin-container" >}}admin container{{< /ver-ref >}}.
-The control container provides a pathway to connect ([via SMM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
+The control container provides a pathway to connect ([via SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
 The control container also provides an entry point to the admin container.
 The admin container allows you to more deeply interact with the host as it mounts the root filesystem and has elevated privileges.
 

--- a/content/en/os/1.16.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.16.x/concepts/host-containers/_index.markdown
@@ -20,7 +20,7 @@ Instead you manage the lifecycle of these containers by manipulating specific {{
 ## Built-in host containers
 
 Depending on the variant, Bottlerocket has two standard host containers: the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#interacting-with-a-bottlerocket-node-through-host-containers" >}}control container{{< /ver-ref >}} and the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#exploring-the-admin-container" >}}admin container{{< /ver-ref >}}.
-The control container provides a pathway to connect ([via SMM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
+The control container provides a pathway to connect ([via SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
 The control container also provides an entry point to the admin container.
 The admin container allows you to more deeply interact with the host as it mounts the root filesystem and has elevated privileges.
 

--- a/content/en/os/1.17.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.17.x/concepts/host-containers/_index.markdown
@@ -20,7 +20,7 @@ Instead you manage the lifecycle of these containers by manipulating specific {{
 ## Built-in host containers
 
 Depending on the variant, Bottlerocket has two standard host containers: the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#interacting-with-a-bottlerocket-node-through-host-containers" >}}control container{{< /ver-ref >}} and the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#exploring-the-admin-container" >}}admin container{{< /ver-ref >}}.
-The control container provides a pathway to connect ([via SMM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
+The control container provides a pathway to connect ([via SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
 The control container also provides an entry point to the admin container.
 The admin container allows you to more deeply interact with the host as it mounts the root filesystem and has elevated privileges.
 

--- a/content/en/os/1.18.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.18.x/concepts/host-containers/_index.markdown
@@ -20,7 +20,7 @@ Instead you manage the lifecycle of these containers by manipulating specific {{
 ## Built-in host containers
 
 Depending on the variant, Bottlerocket has two standard host containers: the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#interacting-with-a-bottlerocket-node-through-host-containers" >}}control container{{< /ver-ref >}} and the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#exploring-the-admin-container" >}}admin container{{< /ver-ref >}}.
-The control container provides a pathway to connect ([via SMM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
+The control container provides a pathway to connect ([via SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
 The control container also provides an entry point to the admin container.
 The admin container allows you to more deeply interact with the host as it mounts the root filesystem and has elevated privileges.
 

--- a/content/en/os/1.19.x/concepts/host-containers/_index.markdown
+++ b/content/en/os/1.19.x/concepts/host-containers/_index.markdown
@@ -20,7 +20,7 @@ Instead you manage the lifecycle of these containers by manipulating specific {{
 ## Built-in host containers
 
 Depending on the variant, Bottlerocket has two standard host containers: the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#interacting-with-a-bottlerocket-node-through-host-containers" >}}control container{{< /ver-ref >}} and the {{< ver-ref project="os" page="/install/quickstart/aws/host-containers#exploring-the-admin-container" >}}admin container{{< /ver-ref >}}.
-The control container provides a pathway to connect ([via SMM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
+The control container provides a pathway to connect ([via SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)) to and interact with the host as well as conveniently access the Bottlerocket API.
 The control container also provides an entry point to the admin container.
 The admin container allows you to more deeply interact with the host as it mounts the root filesystem and has elevated privileges.
 


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #425

**Description of changes:**
Fixes typo when SSM is referred to "SMM" across several docs versions.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
