### PR TITLE
Add links for Brupop in core pages.

### DIFF
--- a/content/en/_index.markdown
+++ b/content/en/_index.markdown
@@ -21,11 +21,15 @@ However, the most fundamental building blocks needed to understand Bottlerocket 
 ## Organization
 
 This documentation is divided by project and largely mirrors the repository boundaries of the Bottlerocket GitHub organization.
-The primary documentation for the operating system is in the OS section and correlates with `bottlerocket-os/bottlerocket` on GitHub.
+
+| GitHub Repo | Section | Description |
+|-------------|---------------|-------------|
+| [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) | [OS](./os/)  | Primary documentation for the operating system. |
+| [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) | [Brupop](./os/)  | Documentation for the Kubernetes operator that automates Bottlerocket updates  |
 
 Inside each section, the documentation is further scoped to minor versions of each project with the most recent release being marked as (*Current*).
 
-Version Information sections contain reference metadata about the documented release.
+Where available, **Version Information** sections contain reference metadata about the documented release.
 
 ## Navigation
 

--- a/content/en/os/_index.markdown
+++ b/content/en/os/_index.markdown
@@ -7,7 +7,8 @@ no_version_warning=true
 weight=2
 +++
 
-This section covers installing and using the Bottlerocket operating system[^1]. If you’re looking for information on building, contributing to, or learning about the inner workings of Bottlerocket, the [GitHub repo](https://github.com/bottlerocket-os/bottlerocket) has more information.
+This section covers installing and using the **Bottlerocket operating system**.
+If you’re looking for information on building, contributing to, or learning about the inner workings of Bottlerocket, the [GitHub repo](https://github.com/bottlerocket-os/bottlerocket) has more information.
 
 ## Organization
 
@@ -17,8 +18,12 @@ The current documented versions:
 
 {{< subsections-list >}}
 
+## Related Projects
+
+Non-OS Bottlerocket projects are covered in other sections ([Bottlerocket Update Operator documentation](../brupop/)) or on their respective GitHub Repos[^1] ([Control Container](https://github.com/bottlerocket-os/bottlerocket-control-container), [Admin Container](https://github.com/bottlerocket-os/bottlerocket-admin-container), [Bottlerocket ECS Updater](https://github.com/bottlerocket-os/bottlerocket-ecs-updater), etc.)
+
 ## Something Missing?
 
 Bottlerocket, like any operating system, is complex and rich with options and configuration. This [documentation is open-source](https://github.com/bottlerocket-os/project-website) and likely incomplete, but will evolve over time to encompass a more complete explanation of the software. Should you find gaps, you’re invited to file issues or contribute.
 
-[^1]: Documentation for projects related to Bottlerocket (such as the Control Container, Admin Container, brupop, etc.) are not present in this documentation and still reside in their respective GitHub repos. In the future, documentation on the use and installation of these tools will migrate to a new section on this site.
+[^1]: In the future, documentation on the use and installation of these tools may migrate to a new section on this site.


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #423

**Description of changes:**
- Refactors` /en/` to include a table relating repos to docs
- Refators `/en/os/` to include a related projects section with links/references to Brupop

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
