### PR TITLE
adds symbolic link for 'latest' functionality in brupop docs

### DIFF
--- a/content/en/brupop/latest.markdown
+++ b/content/en/brupop/latest.markdown
@@ -1,0 +1,1 @@
+../os/latest.markdown


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

Creates a symbolic link for `latest.markdown` from the OS section to Brupop. 

This allows for evergreen links with a forwarder. For example

`/en/brupop/latest#/setup/configure/` forwards to `/en/brupop/1.3.x/setup/configure/` today. 

When Brupop 1.4 comes out:

`/en/brupop/latest#/setup/configure/` forwards to `/en/brupop/1.4.x/setup/configure/`

This is no new code, just reusing existing code to achieve the same functionality in a new place.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
