### PR TITLE
Move to Prod: Forwarder for Brupop

### DIFF
--- a/content/en/_index.markdown
+++ b/content/en/_index.markdown
@@ -25,7 +25,7 @@ This documentation is divided by project and largely mirrors the repository boun
 | GitHub Repo | Section | Description |
 |-------------|---------------|-------------|
 | [`bottlerocket-os/bottlerocket`](https://github.com/bottlerocket-os/bottlerocket) | [OS](./os/)  | Primary documentation for the operating system. |
-| [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) | [Brupop](./os/)  | Documentation for the Kubernetes operator that automates Bottlerocket updates  |
+| [`bottlerocket-os/bottlerocket-update-operator`](https://github.com/bottlerocket-os/bottlerocket-update-operator) | [Brupop](./brupop/)  | Documentation for the Kubernetes operator that automates Bottlerocket updates  |
 
 Inside each section, the documentation is further scoped to minor versions of each project with the most recent release being marked as (*Current*).
 

--- a/content/en/brupop/latest.markdown
+++ b/content/en/brupop/latest.markdown
@@ -1,0 +1,1 @@
+../os/latest.markdown


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

Moves to prod an application the existing evergreen link forwarder used in `/en/os` for use in `/en/brupop`


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
