### PR TITLE
adds hash/latest functionality

### DIFF
--- a/layouts/shortcodes/latest-redirect.html
+++ b/layouts/shortcodes/latest-redirect.html
@@ -34,10 +34,20 @@
         {{- end -}}
         {{/* new `currentVersion` contains only the valid pages in the correct section/langauge/version */}}
         var docs_location;
+        var final_hash = "";
+        var last_hash_location;
         {{/* do we have a hash in the URL? */}}
         if (window.location && window.location.hash) {
             {{/* get the hash portion and snip off the first character (will always be #) */}}
             docs_location = window.location.hash.slice(1); 
+            {{/* get the last hash value for any incoming hash links */}}
+            last_hash_location = docs_location.lastIndexOf("#");
+            {{/* if the last hash value exists, put it in `final_hash` and change docs_location to remove it */}}
+            if (last_hash_location !== -1) {
+                final_hash = window.location.hash.slice(last_hash_location+1);
+                docs_location = window.location.hash.slice(1, last_hash_location+1);
+            }
+
             {{/* does it have a trailing slash? If not, add one to match the Hugo output */}}
             if (docs_location[docs_location.length-1] !== '/') { 
                 docs_location = docs_location + '/';
@@ -45,10 +55,10 @@
             {{/* Is the passed URL fragment in the array? */}}
             if (currentVersion.indexOf(docs_location) !== -1) {
                 {{/* reconstruct the URL with the latest version */}}
-                location.assign(currentURLPrefix + docs_location);
+                location.assign(currentURLPrefix + docs_location + final_hash);
             } else {
                 {{/* otherwise just go to the top of the current version */}}
-                location.assign(currentURLPrefix);
+                location.assign(currentURLPrefix + final_hash);
             }
         }
     })();


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

Currently, you can supply `latest` and a `#` to get a context aware forward to the latest version.

So, for example:
`/en/os/latest#/install/quickstart/aws/host-containers/` would link to `/en/os/1.19.x/install/quickstart/aws/host-containers/` and in the future `/en/os/1.20.x/install/quickstart/aws/host-containers/` (and so on).

However, this doesn't work if you need to deep link to an anchor (e.g. URLs with `#`).

`/en/os/latest#/install/quickstart/aws/host-containers/#prerequisites` forwards to `/en/os/1.19.x/` (because it can't figure out a correct page and fails back to the most recent version).

This commit adds additional logic to look for an additional `#` (the last one). If present, it uses what's before the last `#` as the page and everything afterwards is appended to the end of the URL.

Consequently:
`/en/os/latest#/install/quickstart/aws/host-containers/#prerequisites` forwards to `/en/os/1.19.x/install/quickstart/aws/host-containers/` and jumps the page to `#prerequisites`

Additionally, `/en/os/latest#/install/quickstart/aws/host-containers/` still forwards to `/en/os/1.19.x/install/quickstart/aws/host-containers/` . 

If you supply it with multiple hashes the script still preserves the existing behaviour of falling back to the version directory (e.g.`/en/os/latest#/install/quickstart/aws/host-containers/#foo#prerequisites` will just go to `/en/os/1.19.x/`). 


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
