### PR TITLE
Document where to set kmod parameters from the `settings.kernel.modules` documentation

### DIFF
--- a/data/settings/1.16.x/kernel.toml
+++ b/data/settings/1.16.x/kernel.toml
@@ -27,6 +27,12 @@ warning = "This setting only affects *loading* of kernel modules at boot time. C
 description = """
 Allows (`true`) or disallows (`false`) the loading of kernel module `<name>`. 
 """
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
+note = """
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
+"""
 accepted_values = [
     "`true`",
     "`false`"
@@ -61,9 +67,14 @@ direct_toml = """
 [[docs.ref.modules_autoload]]
 name_override = "modules.<name>.autoload"
 description = "If `true`, the kernel `<name>` module loads automatically on boot."
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
 note = """
 You must use this setting in conjuction with [`settings.kernel.modules.<name>.allowed`](#modules_allowed) on the same module.
 This ensures that the OS doesn't auto-load a blocked module. 
+
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
 """
 accepted_values = [
     "`true`",

--- a/data/settings/1.17.x/kernel.toml
+++ b/data/settings/1.17.x/kernel.toml
@@ -27,6 +27,12 @@ warning = "This setting only affects *loading* of kernel modules at boot time. C
 description = """
 Allows (`true`) or disallows (`false`) the loading of kernel module `<name>`. 
 """
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
+note = """
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
+"""
 accepted_values = [
     "`true`",
     "`false`"
@@ -61,9 +67,14 @@ direct_toml = """
 [[docs.ref.modules_autoload]]
 name_override = "modules.<name>.autoload"
 description = "If `true`, the kernel `<name>` module loads automatically on boot."
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
 note = """
 You must use this setting in conjuction with [`settings.kernel.modules.<name>.allowed`](#modules_allowed) on the same module.
 This ensures that the OS doesn't auto-load a blocked module. 
+
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
 """
 accepted_values = [
     "`true`",

--- a/data/settings/1.18.x/kernel.toml
+++ b/data/settings/1.18.x/kernel.toml
@@ -27,6 +27,12 @@ warning = "This setting only affects *loading* of kernel modules at boot time. C
 description = """
 Allows (`true`) or disallows (`false`) the loading of kernel module `<name>`. 
 """
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
+note = """
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
+"""
 accepted_values = [
     "`true`",
     "`false`"
@@ -61,9 +67,14 @@ direct_toml = """
 [[docs.ref.modules_autoload]]
 name_override = "modules.<name>.autoload"
 description = "If `true`, the kernel `<name>` module loads automatically on boot."
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
 note = """
 You must use this setting in conjuction with [`settings.kernel.modules.<name>.allowed`](#modules_allowed) on the same module.
 This ensures that the OS doesn't auto-load a blocked module. 
+
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
 """
 accepted_values = [
     "`true`",

--- a/data/settings/1.19.x/kernel.toml
+++ b/data/settings/1.19.x/kernel.toml
@@ -27,6 +27,12 @@ warning = "This setting only affects *loading* of kernel modules at boot time. C
 description = """
 Allows (`true`) or disallows (`false`) the loading of kernel module `<name>`. 
 """
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
+note = """
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
+"""
 accepted_values = [
     "`true`",
     "`false`"
@@ -61,9 +67,14 @@ direct_toml = """
 [[docs.ref.modules_autoload]]
 name_override = "modules.<name>.autoload"
 description = "If `true`, the kernel `<name>` module loads automatically on boot."
+see = [
+    [ "settings", "boot", "kernel-parameters" ]
+]
 note = """
 You must use this setting in conjuction with [`settings.kernel.modules.<name>.allowed`](#modules_allowed) on the same module.
 This ensures that the OS doesn't auto-load a blocked module. 
+
+Use [`settings.boot.kernel-parameters`](../boot/#kernel-parameters) to set module parameters through the kernel command line.
 """
 accepted_values = [
     "`true`",


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:** https://github.com/bottlerocket-os/bottlerocket/issues/3747

**Description of changes:**

```
kernel.modules: Reference boot.kernel-parameters for module options

Users of Bottlerocket had asked for an easy way to set module parameters
through user data [0]. That way already exists through kernel-parameters.
Document that settings.boot.kernel-parameters is to be used to set
module options.

Details on why adding extra settings under settings.kernel.modules to
achieve this can be found on the issue [1]

[0] https://github.com/bottlerocket-os/bottlerocket/issues/3747
[1] https://github.com/bottlerocket-os/bottlerocket/issues/3747#issuecomment-1954792175

Signed-off-by: Leonard Foerster <foersleo@amazon.com>
```

I am not quite sure if just linking from the module settings to `kernel-parameters` is enough here. The example at `kernel-parameters` includes a sample module parameter setting through `usbcore.quirks` so I am not sure if we need more.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
