### PR TITLE
removes symlinks, refactors .Page.Dir references for new Hugo version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -51,13 +51,21 @@ ul_show = 1
   [module.hugoVersion]
     extended = true
     min = "0.73.0"
-  [[module.imports]]
-    path = "github.com/google/docsy"
-    disable = false
-  [[module.imports]]
-    path = "github.com/google/docsy/dependencies"
-    disable = false
 
+[[module.imports]]
+  path = "github.com/google/docsy"
+  disable = false
+[[module.imports]]
+  path = "github.com/google/docsy/dependencies"
+  disable = false
+[[module.mounts]]
+  source= "/third-party/google/docsy/layouts/_default"
+  target= "layouts/_default"
+  includeFiles= "baseof.html"
+[[module.mounts]]
+  source= "/third-party/google/docsy/layouts/partials"
+  target= "layouts/partials"
+  includeFiles= ["navbar.html", "footer.html"]
 
 [languages]
   [languages.all]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,1 +1,0 @@
-../../third-party/google/docsy/layouts/_default/baseof.html

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,1 +1,0 @@
-../../third-party/google/docsy/layouts/partials/footer.html

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,5 +1,6 @@
 {{- /* get the directory of the file being rendered */ -}}
-{{- $file := print .Page.File.Dir  -}}
+{{- /* Note: For whatever reason .Page.File.Dir doesn't function with 0.123.8, the strings.Replace works around this issue */}}
+{{- $file := strings.Replace (strings.Replace (print .Page) "Page(/" "") ")" "" -}}
 {{- /* break it apart */ -}}
 {{- $parts := split $file "/" -}}
 {{- /* the first part is the section (aka product 'os', etc.) */ -}}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,10 +1,9 @@
 {{- /* get the directory of the file being rendered */ -}}
-{{- /* Note: For whatever reason .Page.File.Dir doesn't function with 0.123.8, the strings.Replace works around this issue */}}
-{{- $file := strings.Replace (strings.Replace (print .Page) "Page(/" "") ")" "" -}}
+{{- $file := .Page.Path }}
 {{- /* break it apart */ -}}
 {{- $parts := split $file "/" -}}
 {{- /* the first part is the section (aka product 'os', etc.) */ -}}
-{{- $sect := index $parts 0 -}}
+{{- $sect := index $parts 1 -}}
 {{- /* is it in the site data? If so we might need to show a notice and do a rel cannonical */ -}}
 {{- if in $.Site.Data.versioned.sections $sect }}
     {{- /* get the current version parts */ -}}
@@ -14,7 +13,7 @@
     {{- /* but it into the scratch for later page elemnents */ -}}
     {{- .Page.Scratch.Set (print $sect "-latest") $latest -}}
     {{- /* now get the page version from the URL */ -}}
-    {{- $pageVersion := index $parts 1 }}
+    {{- $pageVersion := index $parts 2 }}
     {{- /* if the page version is not equal to the latest, we've got out of date stuff */ -}}
     {{- if (ne $latest $pageVersion) -}}
         {{- /* create the corresponding filename for the newer version (e.g. /en/foo/1.13.x/ -> /en/foo/1.14.x/) */ -}}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,5 +1,5 @@
 {{- /* get the directory of the file being rendered */ -}}
-{{- $file := .Page.Path }}
+{{- $file := .Page.Path -}}
 {{- /* break it apart */ -}}
 {{- $parts := split $file "/" -}}
 {{- /* the first part is the section (aka product 'os', etc.) */ -}}
@@ -13,7 +13,7 @@
     {{- /* but it into the scratch for later page elemnents */ -}}
     {{- .Page.Scratch.Set (print $sect "-latest") $latest -}}
     {{- /* now get the page version from the URL */ -}}
-    {{- $pageVersion := index $parts 2 }}
+    {{- $pageVersion := index $parts 2 -}}
     {{- /* if the page version is not equal to the latest, we've got out of date stuff */ -}}
     {{- if (ne $latest $pageVersion) -}}
         {{- /* create the corresponding filename for the newer version (e.g. /en/foo/1.13.x/ -> /en/foo/1.14.x/) */ -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,1 +1,0 @@
-../../third-party/google/docsy/layouts/partials/navbar.html

--- a/layouts/shortcodes/all-settings.html
+++ b/layouts/shortcodes/all-settings.html
@@ -1,4 +1,4 @@
-{{- $current_version := index (split .Page.File "/") 1  -}}
+{{- $current_version := index (split .Page.File.Dir "/") 1  -}}
 {{- $all_versions := slice  -}}
 {{- $current_version_index := -1  -}}
 {{- $new_badge := .Get "new_badge" }}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a

**Description of changes:**

I had person tell me (off github) that the site wasn't building with the latest hugo.

Upon investigation, I discovered two issues:

1) Symlink support was removed between `0.104.2` and current release (`0.123.8`)
2) The templates used `.Page.File.Dir` and this was causing an obscure error with hugo with the newer versions (see https://github.com/gohugoio/hugo/issues/12221)

This PR works around both issues by moving the symlinks to `module.mounts` and parsing `.Page` to get the path as a string (less than ideal, but I want to unblock usage with the most recent hugo).



**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
