### PR TITLE
adapt to new hugo version

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # based on known good environment
-      HUGO_VERSION: 0.104.2
+      HUGO_VERSION: 0.123.8
     steps:
       - name: Install Hugo CLI
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,16 @@ preview:
 	docker run --rm -it \
 		-v "${PWD}":/src \
 		-p 1313:1313 \
-		klakegg/hugo:0.101.0-ext-alpine \
-		server -w --bind=0.0.0.0
+		hugomods/hugo:exts-0.123.8 \
+		hugo server -w --bind=0.0.0.0
+
+preview_finch:
+	finch run --rm -it \
+		-v "${PWD}":/src \
+		-p 1313:1313 \
+		hugomods/hugo:exts-0.123.8 \
+		hugo server -w --bind=0.0.0.0
+
 
 mdlint:
 	docker run --rm \

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -2,7 +2,9 @@
 .btn-lg, .btn-group-lg > .btn {
     border-radius: 6px;
 }
-
+.d-lg-block.d-none {
+    display: none !important;
+}
 
 ._td-navbar {
     background-color: $dark-teal;
@@ -25,7 +27,7 @@
     }
     .td-sidebar-nav a:hover { color: $dark-teal; }
 }
-.navbar-brand .font-weight-bold { font-weight: 600 !important; }
+.navbar-brand .font-weight-bold { font-weight: 500 !important; }
 .td-home, .td-main, .td-section, .td-page {
     .td-navbar { 
         background: linear-gradient($dark 0%, $dark-blue 10%, $dark-blue 100%);


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes # n/a Related to #449 

**Description of changes:**

Small tweaks to adapt site to new/current version of Hugo
- Change to new docker container for `make preview`
- Adds alternate make for Finch instead of Docker in `make preview`
- Fix two rendering difference between hugo version
- Change the github workflow to use the new version


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
