### PR TITLE
ecs: add `settings.ecs.enable-container-metadata` for 1.19.x

### DIFF
--- a/data/settings/1.19.x/ecs.toml
+++ b/data/settings/1.19.x/ecs.toml
@@ -192,3 +192,13 @@ Valid time units include `s`, `m`, and `h` (e.g. `1h`, `1m1s`).
 tags = [
     "cleanup"
 ]
+
+[[docs.ref.enable-container-metadata]]
+description = """
+When `true`, the agent will create a file describing the container's metadata at
+the path stored in the environment variable `ECS_CONTAINER_METADATA_FILE`
+"""
+default = "`false`"
+see = [
+  ["`ECS_ENABLE_CONTAINER_METADATA` in the [ECS Agent Environment Variables](https://github.com/aws/amazon-ecs-agent/blob/master/README.md#environment-variables)"]
+]


### PR DESCRIPTION
**Issue number:**

Closes #442

**Description of changes:**
Add missing documentation for `settings.ecs.enable-container-metadata`

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
