### PR TITLE
fixes issues with compound toml apiclient examples

### DIFF
--- a/layouts/partials/settings-example-tab-pane.html
+++ b/layouts/partials/settings-example-tab-pane.html
@@ -52,8 +52,16 @@
                     {{ end }}
                 {{ end }}
             {{ else }}
-                {{ $example_scratch.Add "out" (print "apiclient set " )}}
-                {{ $example_scratch.Add "out" (print $setting_full_name "=" $example.value) }}
+                {{/* compound toml examples have [ ] in them, so we have to use a regex to find and render alternately */}}
+                {{ if (findRE `\[(.*?)\]` $example.value) }}
+                    {{ $example_scratch.Add "out" (print "apiclient apply <<EOF\r\n" ) }}
+                    {{ $example_scratch.Add "out" (print "[" $setting_prefix "]\n")}}
+                    {{ $example_scratch.Add "out" (print $setting_id " = " $example.value "\n") }}
+                    {{ $example_scratch.Add "out" "EOF" }}
+                {{ else }}
+                    {{ $example_scratch.Add "out" (print "apiclient set " )}}
+                    {{ $example_scratch.Add "out" (print $setting_full_name "=" $example.value) }}
+                {{ end }}
             {{ end }}
         {{ end }}
     {{ end }}

--- a/layouts/partials/settings-setting-individual.html
+++ b/layouts/partials/settings-setting-individual.html
@@ -67,6 +67,7 @@
         {{ $apiclientTabData.Set "toml" false }}
         {{ $apiclientTabData.Set "active" (not $hasToml) }}
         {{ $apiclientTabData.Set "example" $example }}
+        {{ $apiclientTabData.Set "prefix" $setting_prefix }}
 
         <ul class="nav nav-tabs" role="tablist" id="{{ $setting_id }}ExampleTabs">
             {{- if $hasToml -}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes #447 

**Description of changes:**

Evaluates example values to see if they have compound toml that requires heredoc on the command line. This only affects rendering of settings which have a value that is encoded as a toml in a string.

So, the following settings:
`settings.kubernetes.allowed-unsafe-sysctls`
`settings.kubernetes.cluster-dns-ip`
`settings.kubernetes.cpu-manager-policy-options`
`settings.dns.name-servers`
`settings.dns.search-list`
`settings.network.no-proxy`
`settings.ntp.time-servers`


Before:

![Screenshot 2024-03-22 at 1 50 58 PM](https://github.com/bottlerocket-os/bottlerocket-project-website/assets/1152927/20dafc33-cc39-4c1c-ab2f-86f4b5ce428b)

After:

![Screenshot 2024-03-22 at 1 44 21 PM](https://github.com/bottlerocket-os/bottlerocket-project-website/assets/1152927/99f7cd89-cbcf-4d04-b5e3-3a7c70cc0295)




**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
