### PR TITLE
Add documentation for device-ownership settings

### DIFF
--- a/METADOC-SETTING-DOCS-DSL.md
+++ b/METADOC-SETTING-DOCS-DSL.md
@@ -98,6 +98,7 @@ Hash links and references would still use  `bar-index-baz`.
     * Direct (TOML and shell): A free form representation that will be rendered as written in a syntax highlighter.
       * `direct_toml` (optional, string) A string representation of TOML. Will be put through the [Chroma](https://github.com/alecthomas/chroma) TOML highlighter and placed under a “TOML” tab or heading.
       * `direct_shell` A string representation of apiclient. Will be put through the [Chroma](https://github.com/alecthomas/chroma) shell highlighter and placed under a “apiclient” tab or heading.
+      * `direct_yaml` A string representation of yaml. Will be put through the [Chroma](https://github.com/alecthomas/chroma) yaml highlighter and placed under a “YAML” tab or heading.
 
 ## Adding tags/topics
 

--- a/data/settings/1.30.x/kubernetes.toml
+++ b/data/settings/1.30.x/kubernetes.toml
@@ -625,3 +625,29 @@ accepted_values = [
     "`true`",
     "`false`"
 ]
+
+[[docs.ref.device-ownership-from-security-context]]
+description = """
+Bottlerocket `v1.30.0`+ supports device ownership using the security context provided in the Kubernetes specfile.
+To allow a container to take ownership, you will need to enable ownership through the `apiclient` setting as well as define the `runAsUser` and `runAsGroup` in the securityContext (See sample below)
+"""
+default = "`true` for k8s-1.32+ variants, `false` for other variants"
+accepted_values = [
+    "`true`",
+    "`false`"
+]
+see = [
+    [ "[Kubernetes' documentation](https://kubernetes.io/blog/2021/11/09/non-root-containers-and-devices/) "]
+]
+
+[[docs.ref.device-ownership-from-security-context.example]]
+comment = "Sample securityContext in a specfile to allow device ownership"
+direct_yaml = """
+...
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 2000
+    fsGroup: 3000
+...
+"""

--- a/layouts/partials/settings-example-tab-button.html
+++ b/layouts/partials/settings-example-tab-button.html
@@ -1,9 +1,9 @@
 {{- $setting_id := .Get "id" }}
 {{- $setting_full_name := .Get "full_name" -}}
-{{- $example_toml_or_apiclient := cond (eq (.Get "toml") true) "TOML" "apiclient" -}}
-{{- $highlighter_type := cond (eq (.Get "toml") true) "toml" "shell" -}}
+{{- $example_type := cond (eq (.Get "toml") true) "TOML" (cond (eq (.Get "yaml") true) "YAML" "apiclient") -}}
+{{- $highlighter_type := cond (eq (.Get "toml") true) "toml" (cond (eq (.Get "yaml") true) "yaml" "shell") -}}
 {{- $active_tab := cond (eq (.Get "active") true) "active" "" -}}
 {{- $aria_selected := (eq (.Get "active") true) -}}
 <li class="nav-item" role="presentation">
-    <button class="nav-link {{ $active_tab }}" id="{{ $setting_id }}-example-{{$example_toml_or_apiclient}}-tab" data-toggle="tab" data-target="#{{ $setting_id }}Example{{$example_toml_or_apiclient}}Pane" type="button" role="tab" aria-controls="{{ $example_toml_or_apiclient }}" aria-selected="{{ $aria_selected }}">{{  $example_toml_or_apiclient }}</button>
+    <button class="nav-link {{ $active_tab }}" id="{{ $setting_id }}-example-{{$example_type}}-tab" data-toggle="tab" data-target="#{{ $setting_id }}Example{{$example_type}}Pane" type="button" role="tab" aria-controls="{{ $example_type }}" aria-selected="{{ $aria_selected }}">{{  $example_type }}</button>
 </li>

--- a/layouts/partials/settings-example-tab-pane.html
+++ b/layouts/partials/settings-example-tab-pane.html
@@ -2,11 +2,11 @@
 {{- $setting_full_name := .Get "full_name" -}}
 {{- $setting_prefix := .Get "prefix" -}}
 {{- $active_tab := cond (eq (.Get "active") true) "show active" "" -}}
-{{- $example_toml_or_apiclient := cond (eq (.Get "toml") true) "TOML" "apiclient" -}}
-{{- $highlighter_type := cond (eq (.Get "toml") true) "toml" "shell" -}}
+{{- $example_type := cond (eq (.Get "toml") true) "TOML" (cond (eq (.Get "yaml") true) "YAML" "apiclient") -}}
+{{- $highlighter_type := cond (eq (.Get "toml") true) "toml" (cond (eq (.Get "yaml") true) "yaml" "shell") -}}
 {{- $examples := .Get "example" -}}
 
-<div class="tab-pane fade {{ $active_tab }}" id="{{ $setting_id  }}Example{{ $example_toml_or_apiclient }}Pane" role="tabpanel" aria-labelledby="{{ $setting_id }}-example-{{ $example_toml_or_apiclient }}-tab">
+<div class="tab-pane fade {{ $active_tab }}" id="{{ $setting_id  }}Example{{ $example_type }}Pane" role="tabpanel" aria-labelledby="{{ $setting_id }}-example-{{ $example_type }}-tab">
 {{ range $examples }}
     {{ $example_scratch := newScratch }}
     {{ $example := . }}
@@ -30,6 +30,15 @@
         {{ else }}
             {{ $example_scratch.Add "out" (print "[" $setting_prefix "]\n")}}
             {{ $example_scratch.Add "out" (print $setting_id " = " $example.value) }}
+        {{ end }}
+    {{ else if (eq $highlighter_type "yaml") }}
+        {{ if isset $example "comment" }}
+            {{ $example_scratch.Add "out" (print "# " $example.comment "\n") }}
+        {{ end }}
+        {{ if isset $example "direct_yaml"}}
+            {{ if (gt (len $example.direct_yaml) 0 )}}
+                {{ $example_scratch.Add "out" $example.direct_yaml }}
+            {{ end }}
         {{ end }}
     {{ else }}
         {{ if isset $example "direct_shell"}}

--- a/layouts/partials/settings-setting-individual.html
+++ b/layouts/partials/settings-setting-individual.html
@@ -51,27 +51,50 @@
         {{- $first_example := index $example 0 -}}
         {{ $hasToml := or (isset $first_example "value") (isset $first_example "multiline") (isset $first_example (print "direct_toml" )) }}
         {{ $hasApiClient := or (isset $first_example "value") (isset $first_example "multiline") (isset $first_example (print "direct_shell" )) }}
+        {{/* hasYaml check to only look for direct_yaml for specfile examples, since Bottlerocket only supports toml and shell */}}
+        {{ $hasYaml := false }}
+        {{- range $example -}}
+            {{- if isset . "direct_yaml" -}}
+                {{- if gt (len .direct_yaml) 0 -}}
+                    {{ $hasYaml = true }}
+                {{- end -}}
+            {{- end -}}
+        {{- end -}}
 
 
         {{ $tomlTabData := newScratch }}
         {{ $tomlTabData.Set "id" $setting_id }}
         {{ $tomlTabData.Set "full_name" $setting_full_name }}
         {{ $tomlTabData.Set "toml" true }}
+        {{ $tomlTabData.Set "yaml" false }}
         {{ $tomlTabData.Set "active" true }}
         {{ $tomlTabData.Set "example" $example }}
         {{ $tomlTabData.Set "prefix" $setting_prefix }}
+
+        {{ $yamllTabData := newScratch }}
+        {{ $yamllTabData.Set "id" $setting_id }}
+        {{ $yamllTabData.Set "full_name" $setting_full_name }}
+        {{ $yamllTabData.Set "toml" false }}
+        {{ $yamllTabData.Set "yaml" true }}
+        {{ $yamllTabData.Set "active" (and (not $hasToml) (not $hasApiClient)) }}
+        {{ $yamllTabData.Set "example" $example }}
+        {{ $yamllTabData.Set "prefix" $setting_prefix }}
 
         {{ $apiclientTabData := newScratch }}
         {{ $apiclientTabData.Set "id" $setting_id }}
         {{ $apiclientTabData.Set "full_name" $setting_full_name }}
         {{ $apiclientTabData.Set "toml" false }}
-        {{ $apiclientTabData.Set "active" (not $hasToml) }}
+        {{ $apiclientTabData.Set "yaml" false }}
+        {{ $apiclientTabData.Set "active" (and (not $hasToml) (not $hasYaml)) }}
         {{ $apiclientTabData.Set "example" $example }}
         {{ $apiclientTabData.Set "prefix" $setting_prefix }}
 
         <ul class="nav nav-tabs" role="tablist" id="{{ $setting_id }}ExampleTabs">
             {{- if $hasToml -}}
                 {{ partial "settings-example-tab-button.html" $tomlTabData }}
+            {{- end -}}
+            {{- if $hasYaml -}}
+                {{ partial "settings-example-tab-button.html" $yamllTabData }}
             {{- end -}}
             {{- if $hasApiClient -}}
                 {{ partial "settings-example-tab-button.html" $apiclientTabData }}
@@ -81,6 +104,9 @@
         <div class="tab-content" id="{{ $setting_id }}ExampleContent">
             {{- if $hasToml -}}
                 {{ partial "settings-example-tab-pane.html" $tomlTabData }}
+            {{- end -}}
+            {{- if $hasYaml -}}
+                {{ partial "settings-example-tab-pane.html" $yamllTabData }}
             {{- end -}}
             {{- if $hasApiClient -}}
                 {{ partial "settings-example-tab-pane.html" $apiclientTabData }}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Description of changes:**
- Add new documentation
- Extend settings reference example highlighting to support `yaml`. We don't support yaml as user data so this new `tabpanel` highlight is only active when examples are explicitly marked with `direct_yaml`. It is disabled in all other cases to not confuse between specfile examples and userdata examples.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
