### PR TITLE
Backfill FIPS documentation

### DIFF
--- a/content/en/os/1.28.x/api/reporting/_index.markdown
+++ b/content/en/os/1.28.x/api/reporting/_index.markdown
@@ -17,6 +17,24 @@ You can currently generate reports on your Bottlerocket nodes against two differ
 - [Bottlerocket CIS Benchmark](./cis/)
 - [Kubernetes CIS Benchmark](./cis-k8s)
 
+## FIPS 140-3 for Bottlerocket
+
+Bottlerocket supports running workloads through the Bottlerocket FIPS [variants].
+These variants constrain the kernel and userspace components to the use of cryptographic modules that have been submitted to the FIPS 140-3 [Cryptographic Module Validation Program] \(CMVP\).
+
+This includes the [Amazon Linux 2023 Kernel Cryptographic API] and the [AWS-LC Cryptographic Module].
+In FIPS variants, modules are configured based on their respective security policies.
+You can generate a [Bottlerocket FIPS report] to verify the configuration.
+
+Per the [FedRAMP Policy for Cryptographic Module Selection and Use], Bottlerocket ships the **_updated streams_** for these modules, with the latest patches and updates applied to the software, regardless of the FIPS-validation status of the changed software.
+
+[variants]: ../../concepts/variants
+[Cryptographic Module Validation Program]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-standards
+[Amazon Linux 2023 Kernel Cryptographic API]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4808
+[AWS-LC Cryptographic Module]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631
+[Bottlerocket FIPS report]: ./fips
+[FedRAMP Policy for Cryptographic Module Selection and Use]: https://www.fedramp.gov/rev5/fips/
+
 ## Running a report
 
 You will need to be running the [control container](../../concepts/shell-less-host/#control-container) or, alternately, mount the `apiclient` binary and the Bottlerocket API unix socket into a container as well as have the appropriate SELinux permissions.

--- a/content/en/os/1.28.x/api/reporting/fips/index.markdown
+++ b/content/en/os/1.28.x/api/reporting/fips/index.markdown
@@ -1,0 +1,32 @@
++++
+title = "Bottlerocket FIPS report"
+type = "docs"
+description = "Generating a Bottlerocket FIPS report"
+toc_hide=true
++++
+
+The FIPS report includes information about the state of the FIPS support in the host.
+The report API has built-in tests that allow you to evaluate the state of the node.
+
+> Note: this report is only available on FIPS variants
+
+## Examples
+
+```shell
+apiclient report fips
+
+Benchmark name:  FIPS Security Policy
+Version:         v1.0.0
+Reference:       https://csrc.nist.gov/
+Benchmark level: 1
+Start time:      <>
+
+[PASS] 1.0       FIPS mode is enabled. (Automatic)
+[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
+[PASS] 1.2       FIPS self-tests passed. (Automatic)
+
+Passed:          3
+Failed:          0
+Skipped:         0
+Total checks:    3
+```

--- a/content/en/os/1.28.x/concepts/variants/index.markdown
+++ b/content/en/os/1.28.x/concepts/variants/index.markdown
@@ -50,7 +50,11 @@ When referencing variants in writing, `bottlerocket-` and the commit are typical
 
 ## Flavors
 
-Variants may also package in drivers for specific hardware called a “flavor.” Currently, the only flavor is 'nvidia', which adds support for Nvidia GPUs.
+Variant flavors are used to identify when a variant is built for a specific purpose. The supported flavors include:
+
+- `nvidia`: adds support for NVIDIA GPUs.
+- `fips`: adds support for FIPS 140-3 workloads.
+
 
 ## Variants, updating, & migrating
 

--- a/content/en/os/1.28.x/version-information/fips-modules/_index.markdown
+++ b/content/en/os/1.28.x/version-information/fips-modules/_index.markdown
@@ -1,0 +1,8 @@
++++
+title = "FIPS modules"
+description = "FIPS 140-3 module versions for each Bottlerocket FIPS variant"
+type = "docs"
++++
+{{< page-ver >}}
+
+{{< fips-variant-info  >}}

--- a/content/en/os/1.29.x/api/reporting/_index.markdown
+++ b/content/en/os/1.29.x/api/reporting/_index.markdown
@@ -17,6 +17,24 @@ You can currently generate reports on your Bottlerocket nodes against two differ
 - [Bottlerocket CIS Benchmark](./cis/)
 - [Kubernetes CIS Benchmark](./cis-k8s)
 
+## FIPS 140-3 for Bottlerocket
+
+Bottlerocket supports running workloads through the Bottlerocket FIPS [variants].
+These variants constrain the kernel and userspace components to the use of cryptographic modules that have been submitted to the FIPS 140-3 [Cryptographic Module Validation Program] \(CMVP\).
+
+This includes the [Amazon Linux 2023 Kernel Cryptographic API] and the [AWS-LC Cryptographic Module].
+In FIPS variants, modules are configured based on their respective security policies.
+You can generate a [Bottlerocket FIPS report] to verify the configuration.
+
+Per the [FedRAMP Policy for Cryptographic Module Selection and Use], Bottlerocket ships the **_updated streams_** for these modules, with the latest patches and updates applied to the software, regardless of the FIPS-validation status of the changed software.
+
+[variants]: ../../concepts/variants
+[Cryptographic Module Validation Program]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-standards
+[Amazon Linux 2023 Kernel Cryptographic API]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4808
+[AWS-LC Cryptographic Module]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631
+[Bottlerocket FIPS report]: ./fips
+[FedRAMP Policy for Cryptographic Module Selection and Use]: https://www.fedramp.gov/rev5/fips/
+
 ## Running a report
 
 You will need to be running the [control container](../../concepts/shell-less-host/#control-container) or, alternately, mount the `apiclient` binary and the Bottlerocket API unix socket into a container as well as have the appropriate SELinux permissions.

--- a/content/en/os/1.29.x/api/reporting/fips/index.markdown
+++ b/content/en/os/1.29.x/api/reporting/fips/index.markdown
@@ -1,0 +1,32 @@
++++
+title = "Bottlerocket FIPS report"
+type = "docs"
+description = "Generating a Bottlerocket FIPS report"
+toc_hide=true
++++
+
+The FIPS report includes information about the state of the FIPS support in the host.
+The report API has built-in tests that allow you to evaluate the state of the node.
+
+> Note: this report is only available on FIPS variants
+
+## Examples
+
+```shell
+apiclient report fips
+
+Benchmark name:  FIPS Security Policy
+Version:         v1.0.0
+Reference:       https://csrc.nist.gov/
+Benchmark level: 1
+Start time:      <>
+
+[PASS] 1.0       FIPS mode is enabled. (Automatic)
+[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
+[PASS] 1.2       FIPS self-tests passed. (Automatic)
+
+Passed:          3
+Failed:          0
+Skipped:         0
+Total checks:    3
+```

--- a/content/en/os/1.29.x/concepts/variants/index.markdown
+++ b/content/en/os/1.29.x/concepts/variants/index.markdown
@@ -50,7 +50,11 @@ When referencing variants in writing, `bottlerocket-` and the commit are typical
 
 ## Flavors
 
-Variants may also package in drivers for specific hardware called a “flavor.” Currently, the only flavor is 'nvidia', which adds support for Nvidia GPUs.
+Variant flavors are used to identify when a variant is built for a specific purpose. The supported flavors include:
+
+- `nvidia`: adds support for NVIDIA GPUs.
+- `fips`: adds support for FIPS 140-3 workloads.
+
 
 ## Variants, updating, & migrating
 

--- a/content/en/os/1.29.x/version-information/fips-modules/_index.markdown
+++ b/content/en/os/1.29.x/version-information/fips-modules/_index.markdown
@@ -1,0 +1,8 @@
++++
+title = "FIPS modules"
+description = "FIPS 140-3 module versions for each Bottlerocket FIPS variant"
+type = "docs"
++++
+{{< page-ver >}}
+
+{{< fips-variant-info  >}}

--- a/content/en/os/1.30.x/api/reporting/_index.markdown
+++ b/content/en/os/1.30.x/api/reporting/_index.markdown
@@ -17,6 +17,24 @@ You can currently generate reports on your Bottlerocket nodes against two differ
 - [Bottlerocket CIS Benchmark](./cis/)
 - [Kubernetes CIS Benchmark](./cis-k8s)
 
+## FIPS 140-3 for Bottlerocket
+
+Bottlerocket supports running workloads through the Bottlerocket FIPS [variants].
+These variants constrain the kernel and userspace components to the use of cryptographic modules that have been submitted to the FIPS 140-3 [Cryptographic Module Validation Program] \(CMVP\).
+
+This includes the [Amazon Linux 2023 Kernel Cryptographic API] and the [AWS-LC Cryptographic Module].
+In FIPS variants, modules are configured based on their respective security policies.
+You can generate a [Bottlerocket FIPS report] to verify the configuration.
+
+Per the [FedRAMP Policy for Cryptographic Module Selection and Use], Bottlerocket ships the **_updated streams_** for these modules, with the latest patches and updates applied to the software, regardless of the FIPS-validation status of the changed software.
+
+[variants]: ../../concepts/variants
+[Cryptographic Module Validation Program]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-standards
+[Amazon Linux 2023 Kernel Cryptographic API]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4808
+[AWS-LC Cryptographic Module]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631
+[Bottlerocket FIPS report]: ./fips
+[FedRAMP Policy for Cryptographic Module Selection and Use]: https://www.fedramp.gov/rev5/fips/
+
 ## Running a report
 
 You will need to be running the [control container](../../concepts/shell-less-host/#control-container) or, alternately, mount the `apiclient` binary and the Bottlerocket API unix socket into a container as well as have the appropriate SELinux permissions.

--- a/content/en/os/1.30.x/api/reporting/fips/index.markdown
+++ b/content/en/os/1.30.x/api/reporting/fips/index.markdown
@@ -1,0 +1,32 @@
++++
+title = "Bottlerocket FIPS report"
+type = "docs"
+description = "Generating a Bottlerocket FIPS report"
+toc_hide=true
++++
+
+The FIPS report includes information about the state of the FIPS support in the host.
+The report API has built-in tests that allow you to evaluate the state of the node.
+
+> Note: this report is only available on FIPS variants
+
+## Examples
+
+```shell
+apiclient report fips
+
+Benchmark name:  FIPS Security Policy
+Version:         v1.0.0
+Reference:       https://csrc.nist.gov/
+Benchmark level: 1
+Start time:      <>
+
+[PASS] 1.0       FIPS mode is enabled. (Automatic)
+[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
+[PASS] 1.2       FIPS self-tests passed. (Automatic)
+
+Passed:          3
+Failed:          0
+Skipped:         0
+Total checks:    3
+```

--- a/content/en/os/1.30.x/concepts/variants/index.markdown
+++ b/content/en/os/1.30.x/concepts/variants/index.markdown
@@ -50,7 +50,11 @@ When referencing variants in writing, `bottlerocket-` and the commit are typical
 
 ## Flavors
 
-Variants may also package in drivers for specific hardware called a “flavor.” Currently, the only flavor is 'nvidia', which adds support for Nvidia GPUs.
+Variant flavors are used to identify when a variant is built for a specific purpose. The supported flavors include:
+
+- `nvidia`: adds support for NVIDIA GPUs.
+- `fips`: adds support for FIPS 140-3 workloads.
+
 
 ## Variants, updating, & migrating
 

--- a/content/en/os/1.30.x/version-information/fips-modules/_index.markdown
+++ b/content/en/os/1.30.x/version-information/fips-modules/_index.markdown
@@ -1,0 +1,8 @@
++++
+title = "FIPS modules"
+description = "FIPS 140-3 module versions for each Bottlerocket FIPS variant"
+type = "docs"
++++
+{{< page-ver >}}
+
+{{< fips-variant-info  >}}

--- a/content/en/os/1.31.x/api/reporting/_index.markdown
+++ b/content/en/os/1.31.x/api/reporting/_index.markdown
@@ -17,6 +17,24 @@ You can currently generate reports on your Bottlerocket nodes against two differ
 - [Bottlerocket CIS Benchmark](./cis/)
 - [Kubernetes CIS Benchmark](./cis-k8s)
 
+## FIPS 140-3 for Bottlerocket
+
+Bottlerocket supports running workloads through the Bottlerocket FIPS [variants].
+These variants constrain the kernel and userspace components to the use of cryptographic modules that have been submitted to the FIPS 140-3 [Cryptographic Module Validation Program] \(CMVP\).
+
+This includes the [Amazon Linux 2023 Kernel Cryptographic API] and the [AWS-LC Cryptographic Module].
+In FIPS variants, modules are configured based on their respective security policies.
+You can generate a [Bottlerocket FIPS report] to verify the configuration.
+
+Per the [FedRAMP Policy for Cryptographic Module Selection and Use], Bottlerocket ships the **_updated streams_** for these modules, with the latest patches and updates applied to the software, regardless of the FIPS-validation status of the changed software.
+
+[variants]: ../../concepts/variants
+[Cryptographic Module Validation Program]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-standards
+[Amazon Linux 2023 Kernel Cryptographic API]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4808
+[AWS-LC Cryptographic Module]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631
+[Bottlerocket FIPS report]: ./fips
+[FedRAMP Policy for Cryptographic Module Selection and Use]: https://www.fedramp.gov/rev5/fips/
+
 ## Running a report
 
 You will need to be running the [control container](../../concepts/shell-less-host/#control-container) or, alternately, mount the `apiclient` binary and the Bottlerocket API unix socket into a container as well as have the appropriate SELinux permissions.

--- a/content/en/os/1.31.x/api/reporting/fips/index.markdown
+++ b/content/en/os/1.31.x/api/reporting/fips/index.markdown
@@ -1,0 +1,32 @@
++++
+title = "Bottlerocket FIPS report"
+type = "docs"
+description = "Generating a Bottlerocket FIPS report"
+toc_hide=true
++++
+
+The FIPS report includes information about the state of the FIPS support in the host.
+The report API has built-in tests that allow you to evaluate the state of the node.
+
+> Note: this report is only available on FIPS variants
+
+## Examples
+
+```shell
+apiclient report fips
+
+Benchmark name:  FIPS Security Policy
+Version:         v1.0.0
+Reference:       https://csrc.nist.gov/
+Benchmark level: 1
+Start time:      <>
+
+[PASS] 1.0       FIPS mode is enabled. (Automatic)
+[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
+[PASS] 1.2       FIPS self-tests passed. (Automatic)
+
+Passed:          3
+Failed:          0
+Skipped:         0
+Total checks:    3
+```

--- a/content/en/os/1.31.x/concepts/variants/index.markdown
+++ b/content/en/os/1.31.x/concepts/variants/index.markdown
@@ -50,7 +50,11 @@ When referencing variants in writing, `bottlerocket-` and the commit are typical
 
 ## Flavors
 
-Variants may also package in drivers for specific hardware called a “flavor.” Currently, the only flavor is 'nvidia', which adds support for Nvidia GPUs.
+Variant flavors are used to identify when a variant is built for a specific purpose. The supported flavors include:
+
+- `nvidia`: adds support for NVIDIA GPUs.
+- `fips`: adds support for FIPS 140-3 workloads.
+
 
 ## Variants, updating, & migrating
 

--- a/content/en/os/1.31.x/version-information/fips-modules/_index.markdown
+++ b/content/en/os/1.31.x/version-information/fips-modules/_index.markdown
@@ -1,0 +1,8 @@
++++
+title = "FIPS modules"
+description = "FIPS 140-3 module versions for each Bottlerocket FIPS variant"
+type = "docs"
++++
+{{< page-ver >}}
+
+{{< fips-variant-info  >}}

--- a/content/en/os/1.32.x/api/reporting/_index.markdown
+++ b/content/en/os/1.32.x/api/reporting/_index.markdown
@@ -17,6 +17,24 @@ You can currently generate reports on your Bottlerocket nodes against two differ
 - [Bottlerocket CIS Benchmark](./cis/)
 - [Kubernetes CIS Benchmark](./cis-k8s)
 
+## FIPS 140-3 for Bottlerocket
+
+Bottlerocket supports running workloads through the Bottlerocket FIPS [variants].
+These variants constrain the kernel and userspace components to the use of cryptographic modules that have been submitted to the FIPS 140-3 [Cryptographic Module Validation Program] \(CMVP\).
+
+This includes the [Amazon Linux 2023 Kernel Cryptographic API] and the [AWS-LC Cryptographic Module].
+In FIPS variants, modules are configured based on their respective security policies.
+You can generate a [Bottlerocket FIPS report] to verify the configuration.
+
+Per the [FedRAMP Policy for Cryptographic Module Selection and Use], Bottlerocket ships the **_updated streams_** for these modules, with the latest patches and updates applied to the software, regardless of the FIPS-validation status of the changed software.
+
+[variants]: ../../concepts/variants
+[Cryptographic Module Validation Program]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-standards
+[Amazon Linux 2023 Kernel Cryptographic API]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4808
+[AWS-LC Cryptographic Module]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631
+[Bottlerocket FIPS report]: ./fips
+[FedRAMP Policy for Cryptographic Module Selection and Use]: https://www.fedramp.gov/rev5/fips/
+
 ## Running a report
 
 You will need to be running the [control container](../../concepts/shell-less-host/#control-container) or, alternately, mount the `apiclient` binary and the Bottlerocket API unix socket into a container as well as have the appropriate SELinux permissions.

--- a/content/en/os/1.32.x/api/reporting/fips/index.markdown
+++ b/content/en/os/1.32.x/api/reporting/fips/index.markdown
@@ -1,0 +1,32 @@
++++
+title = "Bottlerocket FIPS report"
+type = "docs"
+description = "Generating a Bottlerocket FIPS report"
+toc_hide=true
++++
+
+The FIPS report includes information about the state of the FIPS support in the host.
+The report API has built-in tests that allow you to evaluate the state of the node.
+
+> Note: this report is only available on FIPS variants
+
+## Examples
+
+```shell
+apiclient report fips
+
+Benchmark name:  FIPS Security Policy
+Version:         v1.0.0
+Reference:       https://csrc.nist.gov/
+Benchmark level: 1
+Start time:      <>
+
+[PASS] 1.0       FIPS mode is enabled. (Automatic)
+[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
+[PASS] 1.2       FIPS self-tests passed. (Automatic)
+
+Passed:          3
+Failed:          0
+Skipped:         0
+Total checks:    3
+```

--- a/content/en/os/1.32.x/concepts/variants/index.markdown
+++ b/content/en/os/1.32.x/concepts/variants/index.markdown
@@ -50,7 +50,11 @@ When referencing variants in writing, `bottlerocket-` and the commit are typical
 
 ## Flavors
 
-Variants may also package in drivers for specific hardware called a “flavor.” Currently, the only flavor is 'nvidia', which adds support for Nvidia GPUs.
+Variant flavors are used to identify when a variant is built for a specific purpose. The supported flavors include:
+
+- `nvidia`: adds support for NVIDIA GPUs.
+- `fips`: adds support for FIPS 140-3 workloads.
+
 
 ## Variants, updating, & migrating
 

--- a/content/en/os/1.32.x/version-information/fips-modules/_index.markdown
+++ b/content/en/os/1.32.x/version-information/fips-modules/_index.markdown
@@ -1,0 +1,8 @@
++++
+title = "FIPS modules"
+description = "FIPS 140-3 module versions for each Bottlerocket FIPS variant"
+type = "docs"
++++
+{{< page-ver >}}
+
+{{< fips-variant-info  >}}

--- a/content/en/os/1.33.x/api/reporting/_index.markdown
+++ b/content/en/os/1.33.x/api/reporting/_index.markdown
@@ -17,6 +17,24 @@ You can currently generate reports on your Bottlerocket nodes against two differ
 - [Bottlerocket CIS Benchmark](./cis/)
 - [Kubernetes CIS Benchmark](./cis-k8s)
 
+## FIPS 140-3 for Bottlerocket
+
+Bottlerocket supports running workloads through the Bottlerocket FIPS [variants].
+These variants constrain the kernel and userspace components to the use of cryptographic modules that have been submitted to the FIPS 140-3 [Cryptographic Module Validation Program] \(CMVP\).
+
+This includes the [Amazon Linux 2023 Kernel Cryptographic API] and the [AWS-LC Cryptographic Module].
+In FIPS variants, modules are configured based on their respective security policies.
+You can generate a [Bottlerocket FIPS report] to verify the configuration.
+
+Per the [FedRAMP Policy for Cryptographic Module Selection and Use], Bottlerocket ships the **_updated streams_** for these modules, with the latest patches and updates applied to the software, regardless of the FIPS-validation status of the changed software.
+
+[variants]: ../../concepts/variants
+[Cryptographic Module Validation Program]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-standards
+[Amazon Linux 2023 Kernel Cryptographic API]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4808
+[AWS-LC Cryptographic Module]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631
+[Bottlerocket FIPS report]: ./fips
+[FedRAMP Policy for Cryptographic Module Selection and Use]: https://www.fedramp.gov/rev5/fips/
+
 ## Running a report
 
 You will need to be running the [control container](../../concepts/shell-less-host/#control-container) or, alternately, mount the `apiclient` binary and the Bottlerocket API unix socket into a container as well as have the appropriate SELinux permissions.

--- a/content/en/os/1.33.x/api/reporting/fips/index.markdown
+++ b/content/en/os/1.33.x/api/reporting/fips/index.markdown
@@ -1,0 +1,32 @@
++++
+title = "Bottlerocket FIPS report"
+type = "docs"
+description = "Generating a Bottlerocket FIPS report"
+toc_hide=true
++++
+
+The FIPS report includes information about the state of the FIPS support in the host.
+The report API has built-in tests that allow you to evaluate the state of the node.
+
+> Note: this report is only available on FIPS variants
+
+## Examples
+
+```shell
+apiclient report fips
+
+Benchmark name:  FIPS Security Policy
+Version:         v1.0.0
+Reference:       https://csrc.nist.gov/
+Benchmark level: 1
+Start time:      <>
+
+[PASS] 1.0       FIPS mode is enabled. (Automatic)
+[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
+[PASS] 1.2       FIPS self-tests passed. (Automatic)
+
+Passed:          3
+Failed:          0
+Skipped:         0
+Total checks:    3
+```

--- a/content/en/os/1.33.x/concepts/variants/index.markdown
+++ b/content/en/os/1.33.x/concepts/variants/index.markdown
@@ -50,7 +50,11 @@ When referencing variants in writing, `bottlerocket-` and the commit are typical
 
 ## Flavors
 
-Variants may also package in drivers for specific hardware called a “flavor.” Currently, the only flavor is 'nvidia', which adds support for Nvidia GPUs.
+Variant flavors are used to identify when a variant is built for a specific purpose. The supported flavors include:
+
+- `nvidia`: adds support for NVIDIA GPUs.
+- `fips`: adds support for FIPS 140-3 workloads.
+
 
 ## Variants, updating, & migrating
 

--- a/content/en/os/1.33.x/version-information/fips-modules/_index.markdown
+++ b/content/en/os/1.33.x/version-information/fips-modules/_index.markdown
@@ -1,0 +1,8 @@
++++
+title = "FIPS modules"
+description = "FIPS 140-3 module versions for each Bottlerocket FIPS variant"
+type = "docs"
++++
+{{< page-ver >}}
+
+{{< fips-variant-info  >}}

--- a/content/en/os/1.34.x/api/reporting/_index.markdown
+++ b/content/en/os/1.34.x/api/reporting/_index.markdown
@@ -17,6 +17,24 @@ You can currently generate reports on your Bottlerocket nodes against two differ
 - [Bottlerocket CIS Benchmark](./cis/)
 - [Kubernetes CIS Benchmark](./cis-k8s)
 
+## FIPS 140-3 for Bottlerocket
+
+Bottlerocket supports running workloads through the Bottlerocket FIPS [variants].
+These variants constrain the kernel and userspace components to the use of cryptographic modules that have been submitted to the FIPS 140-3 [Cryptographic Module Validation Program] \(CMVP\).
+
+This includes the [Amazon Linux 2023 Kernel Cryptographic API] and the [AWS-LC Cryptographic Module].
+In FIPS variants, modules are configured based on their respective security policies.
+You can generate a [Bottlerocket FIPS report] to verify the configuration.
+
+Per the [FedRAMP Policy for Cryptographic Module Selection and Use], Bottlerocket ships the **_updated streams_** for these modules, with the latest patches and updates applied to the software, regardless of the FIPS-validation status of the changed software.
+
+[variants]: ../../concepts/variants
+[Cryptographic Module Validation Program]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-standards
+[Amazon Linux 2023 Kernel Cryptographic API]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4808
+[AWS-LC Cryptographic Module]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631
+[Bottlerocket FIPS report]: ./fips
+[FedRAMP Policy for Cryptographic Module Selection and Use]: https://www.fedramp.gov/rev5/fips/
+
 ## Running a report
 
 You will need to be running the [control container](../../concepts/shell-less-host/#control-container) or, alternately, mount the `apiclient` binary and the Bottlerocket API unix socket into a container as well as have the appropriate SELinux permissions.

--- a/content/en/os/1.34.x/api/reporting/fips/index.markdown
+++ b/content/en/os/1.34.x/api/reporting/fips/index.markdown
@@ -1,0 +1,32 @@
++++
+title = "Bottlerocket FIPS report"
+type = "docs"
+description = "Generating a Bottlerocket FIPS report"
+toc_hide=true
++++
+
+The FIPS report includes information about the state of the FIPS support in the host.
+The report API has built-in tests that allow you to evaluate the state of the node.
+
+> Note: this report is only available on FIPS variants
+
+## Examples
+
+```shell
+apiclient report fips
+
+Benchmark name:  FIPS Security Policy
+Version:         v1.0.0
+Reference:       https://csrc.nist.gov/
+Benchmark level: 1
+Start time:      <>
+
+[PASS] 1.0       FIPS mode is enabled. (Automatic)
+[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
+[PASS] 1.2       FIPS self-tests passed. (Automatic)
+
+Passed:          3
+Failed:          0
+Skipped:         0
+Total checks:    3
+```

--- a/content/en/os/1.34.x/concepts/variants/index.markdown
+++ b/content/en/os/1.34.x/concepts/variants/index.markdown
@@ -50,7 +50,11 @@ When referencing variants in writing, `bottlerocket-` and the commit are typical
 
 ## Flavors
 
-Variants may also package in drivers for specific hardware called a “flavor.” Currently, the only flavor is 'nvidia', which adds support for Nvidia GPUs.
+Variant flavors are used to identify when a variant is built for a specific purpose. The supported flavors include:
+
+- `nvidia`: adds support for NVIDIA GPUs.
+- `fips`: adds support for FIPS 140-3 workloads.
+
 
 ## Variants, updating, & migrating
 

--- a/content/en/os/1.34.x/version-information/fips-modules/_index.markdown
+++ b/content/en/os/1.34.x/version-information/fips-modules/_index.markdown
@@ -1,0 +1,8 @@
++++
+title = "FIPS modules"
+description = "FIPS 140-3 module versions for each Bottlerocket FIPS variant"
+type = "docs"
++++
+{{< page-ver >}}
+
+{{< fips-variant-info  >}}

--- a/data/settings/1.28.x/aws.toml
+++ b/data/settings/1.28.x/aws.toml
@@ -2,6 +2,38 @@
 description = """
 The base64-encoded representation of data used to populate `~/.aws/config`
 """
+
+default = """
+A minimal configuration to enable or disable the [AWS FIPS endpoints], depending on the [variant flavor]
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+[variant flavor]: ../../../concepts/variants/#flavors
+"""
+
+note = """
+Bottlerocket FIPS variants are available all AWS and AWS GovCloud regions. 
+However, in regions without FIPS support (those outside of the US and Canada), **you must opt-out** from using [AWS FIPS endpoints] by updating the `settings.aws.confg` API with the encoded AWS config to disable AWS FIPS endpoints.
+You can use the following values in your nodes to opt-out from using FIPS endpoints in AWS API calls.
+
+```toml
+[settings.aws]
+config = "W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+```shell
+apiclient set settings.aws.config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+The `base64` string corresponds to the following configuration:
+
+```text
+[default]
+use_fips_endpoint=false
+```
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+"""
+
 warning = """
 Avoid adding a `[profile default]` section.
 Recent versions of `aws-iam-authenticator` (and perhaps other components) pick up the default credential settings when `settings.aws.profile` is set to `default`.

--- a/data/settings/1.29.x/aws.toml
+++ b/data/settings/1.29.x/aws.toml
@@ -2,6 +2,38 @@
 description = """
 The base64-encoded representation of data used to populate `~/.aws/config`
 """
+
+default = """
+A minimal configuration to enable or disable the [AWS FIPS endpoints], depending on the [variant flavor]
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+[variant flavor]: ../../../concepts/variants/#flavors
+"""
+
+note = """
+Bottlerocket FIPS variants are available all AWS and AWS GovCloud regions. 
+However, in regions without FIPS support (those outside of the US and Canada), **you must opt-out** from using [AWS FIPS endpoints] by updating the `settings.aws.confg` API with the encoded AWS config to disable AWS FIPS endpoints.
+You can use the following values in your nodes to opt-out from using FIPS endpoints in AWS API calls.
+
+```toml
+[settings.aws]
+config = "W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+```shell
+apiclient set settings.aws.config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+The `base64` string corresponds to the following configuration:
+
+```text
+[default]
+use_fips_endpoint=false
+```
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+"""
+
 warning = """
 Avoid adding a `[profile default]` section.
 Recent versions of `aws-iam-authenticator` (and perhaps other components) pick up the default credential settings when `settings.aws.profile` is set to `default`.

--- a/data/settings/1.30.x/aws.toml
+++ b/data/settings/1.30.x/aws.toml
@@ -2,6 +2,38 @@
 description = """
 The base64-encoded representation of data used to populate `~/.aws/config`
 """
+
+default = """
+A minimal configuration to enable or disable the [AWS FIPS endpoints], depending on the [variant flavor]
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+[variant flavor]: ../../../concepts/variants/#flavors
+"""
+
+note = """
+Bottlerocket FIPS variants are available all AWS and AWS GovCloud regions. 
+However, in regions without FIPS support (those outside of the US and Canada), **you must opt-out** from using [AWS FIPS endpoints] by updating the `settings.aws.confg` API with the encoded AWS config to disable AWS FIPS endpoints.
+You can use the following values in your nodes to opt-out from using FIPS endpoints in AWS API calls.
+
+```toml
+[settings.aws]
+config = "W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+```shell
+apiclient set settings.aws.config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+The `base64` string corresponds to the following configuration:
+
+```text
+[default]
+use_fips_endpoint=false
+```
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+"""
+
 warning = """
 Avoid adding a `[profile default]` section.
 Recent versions of `aws-iam-authenticator` (and perhaps other components) pick up the default credential settings when `settings.aws.profile` is set to `default`.

--- a/data/settings/1.31.x/aws.toml
+++ b/data/settings/1.31.x/aws.toml
@@ -2,6 +2,38 @@
 description = """
 The base64-encoded representation of data used to populate `~/.aws/config`
 """
+
+default = """
+A minimal configuration to enable or disable the [AWS FIPS endpoints], depending on the [variant flavor]
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+[variant flavor]: ../../../concepts/variants/#flavors
+"""
+
+note = """
+Bottlerocket FIPS variants are available all AWS and AWS GovCloud regions. 
+However, in regions without FIPS support (those outside of the US and Canada), **you must opt-out** from using [AWS FIPS endpoints] by updating the `settings.aws.confg` API with the encoded AWS config to disable AWS FIPS endpoints.
+You can use the following values in your nodes to opt-out from using FIPS endpoints in AWS API calls.
+
+```toml
+[settings.aws]
+config = "W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+```shell
+apiclient set settings.aws.config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+The `base64` string corresponds to the following configuration:
+
+```text
+[default]
+use_fips_endpoint=false
+```
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+"""
+
 warning = """
 Avoid adding a `[profile default]` section.
 Recent versions of `aws-iam-authenticator` (and perhaps other components) pick up the default credential settings when `settings.aws.profile` is set to `default`.

--- a/data/settings/1.32.x/aws.toml
+++ b/data/settings/1.32.x/aws.toml
@@ -2,6 +2,38 @@
 description = """
 The base64-encoded representation of data used to populate `~/.aws/config`
 """
+
+default = """
+A minimal configuration to enable or disable the [AWS FIPS endpoints], depending on the [variant flavor]
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+[variant flavor]: ../../../concepts/variants/#flavors
+"""
+
+note = """
+Bottlerocket FIPS variants are available all AWS and AWS GovCloud regions. 
+However, in regions without FIPS support (those outside of the US and Canada), **you must opt-out** from using [AWS FIPS endpoints] by updating the `settings.aws.confg` API with the encoded AWS config to disable AWS FIPS endpoints.
+You can use the following values in your nodes to opt-out from using FIPS endpoints in AWS API calls.
+
+```toml
+[settings.aws]
+config = "W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+```shell
+apiclient set settings.aws.config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+The `base64` string corresponds to the following configuration:
+
+```text
+[default]
+use_fips_endpoint=false
+```
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+"""
+
 warning = """
 Avoid adding a `[profile default]` section.
 Recent versions of `aws-iam-authenticator` (and perhaps other components) pick up the default credential settings when `settings.aws.profile` is set to `default`.

--- a/data/settings/1.33.x/aws.toml
+++ b/data/settings/1.33.x/aws.toml
@@ -2,6 +2,38 @@
 description = """
 The base64-encoded representation of data used to populate `~/.aws/config`
 """
+
+default = """
+A minimal configuration to enable or disable the [AWS FIPS endpoints], depending on the [variant flavor]
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+[variant flavor]: ../../../concepts/variants/#flavors
+"""
+
+note = """
+Bottlerocket FIPS variants are available all AWS and AWS GovCloud regions. 
+However, in regions without FIPS support (those outside of the US and Canada), **you must opt-out** from using [AWS FIPS endpoints] by updating the `settings.aws.confg` API with the encoded AWS config to disable AWS FIPS endpoints.
+You can use the following values in your nodes to opt-out from using FIPS endpoints in AWS API calls.
+
+```toml
+[settings.aws]
+config = "W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+```shell
+apiclient set settings.aws.config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+The `base64` string corresponds to the following configuration:
+
+```text
+[default]
+use_fips_endpoint=false
+```
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+"""
+
 warning = """
 Avoid adding a `[profile default]` section.
 Recent versions of `aws-iam-authenticator` (and perhaps other components) pick up the default credential settings when `settings.aws.profile` is set to `default`.

--- a/data/settings/1.34.x/aws.toml
+++ b/data/settings/1.34.x/aws.toml
@@ -2,6 +2,38 @@
 description = """
 The base64-encoded representation of data used to populate `~/.aws/config`
 """
+
+default = """
+A minimal configuration to enable or disable the [AWS FIPS endpoints], depending on the [variant flavor]
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+[variant flavor]: ../../../concepts/variants/#flavors
+"""
+
+note = """
+Bottlerocket FIPS variants are available all AWS and AWS GovCloud regions. 
+However, in regions without FIPS support (those outside of the US and Canada), **you must opt-out** from using [AWS FIPS endpoints] by updating the `settings.aws.confg` API with the encoded AWS config to disable AWS FIPS endpoints.
+You can use the following values in your nodes to opt-out from using FIPS endpoints in AWS API calls.
+
+```toml
+[settings.aws]
+config = "W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+```shell
+apiclient set settings.aws.config="W2RlZmF1bHRdCnVzZV9maXBzX2VuZHBvaW50PWZhbHNl"
+```
+
+The `base64` string corresponds to the following configuration:
+
+```text
+[default]
+use_fips_endpoint=false
+```
+
+[AWS FIPS endpoints]: https://docs.aws.amazon.com/general/latest/gr/rande.html#FIPS-endpoints
+"""
+
 warning = """
 Avoid adding a `[profile default]` section.
 Recent versions of `aws-iam-authenticator` (and perhaps other components) pick up the default credential settings when `settings.aws.profile` is set to `default`.


### PR DESCRIPTION
**Issue number:**

Closes #513

**Description of changes:**

Backfill FIPS documentation from 1.28.x to 1.34.x. This is just a blank copy of the content files that must be updated.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
