### PR TITLE
fix: oci-defaults.resource-limits.max-open-files defaults for 1.14.x+

### DIFF
--- a/data/settings/1.14.x/oci-defaults.toml
+++ b/data/settings/1.14.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.15.x/oci-defaults.toml
+++ b/data/settings/1.15.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.16.x/oci-defaults.toml
+++ b/data/settings/1.16.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.17.x/oci-defaults.toml
+++ b/data/settings/1.17.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.18.x/oci-defaults.toml
+++ b/data/settings/1.18.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.19.x/oci-defaults.toml
+++ b/data/settings/1.19.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.20.x/oci-defaults.toml
+++ b/data/settings/1.20.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.21.x/oci-defaults.toml
+++ b/data/settings/1.21.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.22.x/oci-defaults.toml
+++ b/data/settings/1.22.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.23.x/oci-defaults.toml
+++ b/data/settings/1.23.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.24.x/oci-defaults.toml
+++ b/data/settings/1.24.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.25.x/oci-defaults.toml
+++ b/data/settings/1.25.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.26.x/oci-defaults.toml
+++ b/data/settings/1.26.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.27.x/oci-defaults.toml
+++ b/data/settings/1.27.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.28.x/oci-defaults.toml
+++ b/data/settings/1.28.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.29.x/oci-defaults.toml
+++ b/data/settings/1.29.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.30.x/oci-defaults.toml
+++ b/data/settings/1.30.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.31.x/oci-defaults.toml
+++ b/data/settings/1.31.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.32.x/oci-defaults.toml
+++ b/data/settings/1.32.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.33.x/oci-defaults.toml
+++ b/data/settings/1.33.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.34.x/oci-defaults.toml
+++ b/data/settings/1.34.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.35.x/oci-defaults.toml
+++ b/data/settings/1.35.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.36.x/oci-defaults.toml
+++ b/data/settings/1.36.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.37.x/oci-defaults.toml
+++ b/data/settings/1.37.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.38.x/oci-defaults.toml
+++ b/data/settings/1.38.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.39.x/oci-defaults.toml
+++ b/data/settings/1.39.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.40.x/oci-defaults.toml
+++ b/data/settings/1.40.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]

--- a/data/settings/1.41.x/oci-defaults.toml
+++ b/data/settings/1.41.x/oci-defaults.toml
@@ -690,7 +690,7 @@ accepted_values = [
     "Setting a limit: `0` to `9223372036854775807` (i.e. `int64::MAX`)",
     "Removing a limit: `-1` or `\"unlimited\"`"
 ]
-default = "`soft-limit` is `65536` and `hard-limit` is `1048576`"
+default = "For Kubernetes variants: `soft-limit` is `65536` and `hard-limit` is `1048576`. For ECS variants: `soft-limit` is `1024` and `hard-limit` is `4096`."
 see = [
     ["`RLIMIT_NOFILE` on the [Linux `getrlimit` manual page](https://man7.org/linux/man-pages/man2/getrlimit.2.html)"]
 ]


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket/issues/4583

**Description of changes:**

Current `oci-defaults.resource-limits.max-open-files` defaults only applies to `k8s` variants. Updating to include defaults for `ecs` variants.

Applies to versions 1.14.x to 1.41.x

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
