### PR TITLE
Update kernel parameters for FIPS variants

### DIFF
--- a/data/variants/1.27.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.27.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.27.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.27.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.27.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.27.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.27.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.27.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.27.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.27.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.27.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.27.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.27.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.27.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.27.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.27.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.27.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.27.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.28.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.28.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.28.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.28.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.28.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.28.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.28.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.28.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.28.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.28.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.28.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.28.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.28.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.28.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.28.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.28.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.28.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.28.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.29.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.29.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.29.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.29.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.29.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.29.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.29.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.29.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.29.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.29.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.29.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.29.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.29.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.29.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.29.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.29.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.29.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.29.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.30.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.30.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.30.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.30.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.30.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.30.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.30.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.30.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.30.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.30.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.30.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.30.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.30.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.30.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.30.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.30.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.30.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.30.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.30.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.30.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.30.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.30.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.31.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.31.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.31.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.31.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.31.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.31.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.31.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.31.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.31.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.31.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.31.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.31.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.31.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.31.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.31.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.31.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.31.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.31.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.31.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.31.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.31.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.31.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.32.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.32.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.32.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.32.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.32.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.32.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.32.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.32.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.32.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.32.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.32.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.32.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.32.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.32.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.32.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.32.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.32.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.32.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.32.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.32.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.32.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.32.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.33.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.33.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.33.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.33.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.33.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.33.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.33.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.33.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.33.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.33.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.33.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.33.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.33.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.33.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.33.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.33.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.33.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.33.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.33.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.33.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.33.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.33.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.34.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.34.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.34.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.34.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.34.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.34.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.34.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.34.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.34.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.34.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.34.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.34.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.34.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.34.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.34.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.34.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.34.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.34.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.34.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.34.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.34.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.34.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.35.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.35.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.35.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.35.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.35.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.35.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.35.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.35.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.35.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.35.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.35.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.35.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.35.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.35.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.35.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.35.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.35.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.35.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.35.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.35.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.35.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.35.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.36.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.36.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.36.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.36.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.36.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.36.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.36.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.36.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.36.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.36.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.36.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.36.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.36.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.36.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.36.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.36.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.36.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.36.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.36.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.36.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.36.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.36.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.37.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.37.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.37.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.37.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.37.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.37.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.37.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.37.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.37.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.37.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.37.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.37.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.37.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.37.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.37.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.37.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.37.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.37.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.37.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.37.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.37.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.37.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.38.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.38.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.38.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.38.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.38.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.38.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.38.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.38.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.38.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.38.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.38.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.38.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.38.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.38.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.38.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.38.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.38.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.38.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.38.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.38.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.38.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.38.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.39.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.39.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.39.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.39.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.39.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.39.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.39.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.39.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.39.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.39.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.39.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.39.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.39.x/aws-k8s-1.33-fips.toml
+++ b/data/variants/1.39.x/aws-k8s-1.33-fips.toml
@@ -36,6 +36,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.39.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.39.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.39.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.39.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.39.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.39.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.39.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.39.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.39.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.39.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.39.x/vmware-k8s-1.33-fips.toml
+++ b/data/variants/1.39.x/vmware-k8s-1.33-fips.toml
@@ -31,6 +31,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.40.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.40.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.40.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.40.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.40.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.40.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.40.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.40.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.40.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.40.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.40.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.40.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.40.x/aws-k8s-1.33-fips.toml
+++ b/data/variants/1.40.x/aws-k8s-1.33-fips.toml
@@ -36,6 +36,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.40.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.40.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.40.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.40.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.40.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.40.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.40.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.40.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.40.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.40.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.40.x/vmware-k8s-1.33-fips.toml
+++ b/data/variants/1.40.x/vmware-k8s-1.33-fips.toml
@@ -31,6 +31,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.41.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.41.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.41.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.41.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.41.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.41.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.41.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.41.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.41.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.41.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.41.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.41.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.41.x/aws-k8s-1.33-fips.toml
+++ b/data/variants/1.41.x/aws-k8s-1.33-fips.toml
@@ -36,6 +36,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.41.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.41.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.41.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.41.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.41.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.41.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.41.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.41.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.41.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.41.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.41.x/vmware-k8s-1.33-fips.toml
+++ b/data/variants/1.41.x/vmware-k8s-1.33-fips.toml
@@ -31,6 +31,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.42.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.42.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.42.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.42.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.42.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.42.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.42.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.42.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.42.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.42.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.42.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.42.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.42.x/aws-k8s-1.33-fips.toml
+++ b/data/variants/1.42.x/aws-k8s-1.33-fips.toml
@@ -36,6 +36,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.42.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.42.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.42.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.42.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.42.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.42.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.42.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.42.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.42.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.42.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.42.x/vmware-k8s-1.33-fips.toml
+++ b/data/variants/1.42.x/vmware-k8s-1.33-fips.toml
@@ -31,6 +31,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.43.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.43.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.43.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.43.x/aws-k8s-1.28-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.43.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.43.x/aws-k8s-1.29-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.43.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.43.x/aws-k8s-1.30-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.43.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.43.x/aws-k8s-1.31-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.43.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.43.x/aws-k8s-1.32-fips.toml
@@ -34,6 +34,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.43.x/aws-k8s-1.33-fips.toml
+++ b/data/variants/1.43.x/aws-k8s-1.33-fips.toml
@@ -36,6 +36,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.43.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.43.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.43.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.43.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.43.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.43.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.43.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.43.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.43.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.43.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.43.x/vmware-k8s-1.33-fips.toml
+++ b/data/variants/1.43.x/vmware-k8s-1.33-fips.toml
@@ -31,6 +31,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.44.x/aws-ecs-2-fips.toml
+++ b/data/variants/1.44.x/aws-ecs-2-fips.toml
@@ -33,6 +33,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.44.x/aws-k8s-1.28-fips.toml
+++ b/data/variants/1.44.x/aws-k8s-1.28-fips.toml
@@ -35,6 +35,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.44.x/aws-k8s-1.29-fips.toml
+++ b/data/variants/1.44.x/aws-k8s-1.29-fips.toml
@@ -35,6 +35,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.44.x/aws-k8s-1.30-fips.toml
+++ b/data/variants/1.44.x/aws-k8s-1.30-fips.toml
@@ -35,6 +35,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.44.x/aws-k8s-1.31-fips.toml
+++ b/data/variants/1.44.x/aws-k8s-1.31-fips.toml
@@ -35,6 +35,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.44.x/aws-k8s-1.32-fips.toml
+++ b/data/variants/1.44.x/aws-k8s-1.32-fips.toml
@@ -35,6 +35,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.44.x/aws-k8s-1.33-fips.toml
+++ b/data/variants/1.44.x/aws-k8s-1.33-fips.toml
@@ -37,6 +37,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 
 [lib]

--- a/data/variants/1.44.x/vmware-k8s-1.28-fips.toml
+++ b/data/variants/1.44.x/vmware-k8s-1.28-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.44.x/vmware-k8s-1.29-fips.toml
+++ b/data/variants/1.44.x/vmware-k8s-1.29-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.44.x/vmware-k8s-1.30-fips.toml
+++ b/data/variants/1.44.x/vmware-k8s-1.30-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.44.x/vmware-k8s-1.31-fips.toml
+++ b/data/variants/1.44.x/vmware-k8s-1.31-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.44.x/vmware-k8s-1.32-fips.toml
+++ b/data/variants/1.44.x/vmware-k8s-1.32-fips.toml
@@ -30,6 +30,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core

--- a/data/variants/1.44.x/vmware-k8s-1.33-fips.toml
+++ b/data/variants/1.44.x/vmware-k8s-1.33-fips.toml
@@ -31,6 +31,8 @@ kernel-parameters = [
     "net.ifnames=0",
     "netdog.default-interface=eth0:dhcp4,dhcp6?",
     "quiet",
+    "kernel.fips=1",
+    "init.systemd.unit=fipscheck.target",
 ]
 included-packages = [
     # core


### PR DESCRIPTION
**Issue number:**

Closes #539

**Description of changes:**
The kernel parameters for the FIPS variants were incomplete. Update all the variants since the first Bottlerocket release that included FIPS support.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
