### PR TITLE
fix: add k8s reserved-cpus setting for v1.21.x+

### DIFF
--- a/data/settings/1.21.x/kubernetes.toml
+++ b/data/settings/1.21.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.22.x/kubernetes.toml
+++ b/data/settings/1.22.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.23.x/kubernetes.toml
+++ b/data/settings/1.23.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.24.x/kubernetes.toml
+++ b/data/settings/1.24.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.25.x/kubernetes.toml
+++ b/data/settings/1.25.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.26.x/kubernetes.toml
+++ b/data/settings/1.26.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.27.x/kubernetes.toml
+++ b/data/settings/1.27.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.28.x/kubernetes.toml
+++ b/data/settings/1.28.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.29.x/kubernetes.toml
+++ b/data/settings/1.29.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.30.x/kubernetes.toml
+++ b/data/settings/1.30.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.31.x/kubernetes.toml
+++ b/data/settings/1.31.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.32.x/kubernetes.toml
+++ b/data/settings/1.32.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.33.x/kubernetes.toml
+++ b/data/settings/1.33.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.34.x/kubernetes.toml
+++ b/data/settings/1.34.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.35.x/kubernetes.toml
+++ b/data/settings/1.35.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.36.x/kubernetes.toml
+++ b/data/settings/1.36.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.37.x/kubernetes.toml
+++ b/data/settings/1.37.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.38.x/kubernetes.toml
+++ b/data/settings/1.38.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.39.x/kubernetes.toml
+++ b/data/settings/1.39.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.40.x/kubernetes.toml
+++ b/data/settings/1.40.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.41.x/kubernetes.toml
+++ b/data/settings/1.41.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.42.x/kubernetes.toml
+++ b/data/settings/1.42.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.43.x/kubernetes.toml
+++ b/data/settings/1.43.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.

--- a/data/settings/1.44.x/kubernetes.toml
+++ b/data/settings/1.44.x/kubernetes.toml
@@ -407,6 +407,16 @@ see = [
     [ "[`registryPullQPS` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
 ]
 
+[[docs.ref.reserved-cpus]]
+description = "The specific CPU cores to reserve exclusively for system processes. Follows the `cpuset` format."
+see = [
+    [ "[`reservedSystemCPUs` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)" ]
+]
+
+[[docs.ref.reserved-cpus.example]]
+comment = "Example user data for reserving cores 0, 3, 4, 5, and 8"
+value = "\"0,3-5,8\""
+
 [[docs.ref.server-tls-bootstrap]]
 description = """
 Enables or disables server certificate bootstrap.


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/3788

**Description of changes:**

User [here](https://github.com/bottlerocket-os/bottlerocket/issues/3788#issuecomment-3155715759) is asking for the `reservedSystemCPUs` k8s setting to be added to Bottlerocket. Bottlerocket has had this setting -- called `reserved-cpus` -- since v1.21.0 ([source](https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/2d4790f6df9dac034322bdfeaca01d0d4707ee77)) but the website doesn't have documentation for it.

Adding docs for the `reserved-cpus` setting for v1.21.x+.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
