### PR TITLE
fix: add k8s hostname-override-source and deprecate pod-infra-container-image for v1.21.x+

### DIFF
--- a/data/settings/1.21.x/kubernetes.toml
+++ b/data/settings/1.21.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.22.x/kubernetes.toml
+++ b/data/settings/1.22.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.23.x/kubernetes.toml
+++ b/data/settings/1.23.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.24.x/kubernetes.toml
+++ b/data/settings/1.24.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.25.x/kubernetes.toml
+++ b/data/settings/1.25.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.26.x/kubernetes.toml
+++ b/data/settings/1.26.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.27.x/kubernetes.toml
+++ b/data/settings/1.27.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.28.x/kubernetes.toml
+++ b/data/settings/1.28.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.29.x/kubernetes.toml
+++ b/data/settings/1.29.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.30.x/kubernetes.toml
+++ b/data/settings/1.30.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.31.x/kubernetes.toml
+++ b/data/settings/1.31.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.32.x/kubernetes.toml
+++ b/data/settings/1.32.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.33.x/kubernetes.toml
+++ b/data/settings/1.33.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.34.x/kubernetes.toml
+++ b/data/settings/1.34.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.35.x/kubernetes.toml
+++ b/data/settings/1.35.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.36.x/kubernetes.toml
+++ b/data/settings/1.36.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.37.x/kubernetes.toml
+++ b/data/settings/1.37.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.38.x/kubernetes.toml
+++ b/data/settings/1.38.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.39.x/kubernetes.toml
+++ b/data/settings/1.39.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.40.x/kubernetes.toml
+++ b/data/settings/1.40.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.41.x/kubernetes.toml
+++ b/data/settings/1.41.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.42.x/kubernetes.toml
+++ b/data/settings/1.42.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.43.x/kubernetes.toml
+++ b/data/settings/1.43.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.44.x/kubernetes.toml
+++ b/data/settings/1.44.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.45.x/kubernetes.toml
+++ b/data/settings/1.45.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.46.x/kubernetes.toml
+++ b/data/settings/1.46.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.47.x/kubernetes.toml
+++ b/data/settings/1.47.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.48.x/kubernetes.toml
+++ b/data/settings/1.48.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."

--- a/data/settings/1.49.x/kubernetes.toml
+++ b/data/settings/1.49.x/kubernetes.toml
@@ -601,10 +601,11 @@ see = [
 description = "The IP address of the node."
 
 [[docs.ref.pod-infra-container-image]]
-description = "The URI of the 'pause' container."
-see = [
-    [ "[`--pod-infra-container-image` in Kubelet Options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#options)" ]
-]
+deprecated = true
+description = """
+Bottlerocket ships the pause container image as of v1.21.0, so this setting provides no functionality.
+The setting still exists for backwards compatibility.
+"""
 
 [[docs.ref.max-pods]]
 description = "The maximum number of pods that can be scheduled on this node (limited by number of available IPv4 addresses)."


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-project-website/issues/547, https://github.com/bottlerocket-os/bottlerocket-project-website/issues/550

**Description of changes:**

Add missing docs for `settings.kubernetes.hostname-override-source`. This setting was added [here](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/59) and released in [core-kit v2.3.1 ](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/CHANGELOG.md#v231-2024-08-01)and [AMI v1.21.0](https://github.com/bottlerocket-os/bottlerocket/blob/develop/CHANGELOG.md#v1210-2024-08-06).

Also, deprecate `settings.kubernetes.pod-infra-container-image` setting for v1.21.x+ as [Bottlerocket began to ship the pause container image in 1.21.0.](https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.21.0)

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
