### PR TITLE
chore: fix seccomp default value for v1.33+

### DIFF
--- a/data/settings/1.39.x/kubernetes.toml
+++ b/data/settings/1.39.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.40.x/kubernetes.toml
+++ b/data/settings/1.40.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.41.x/kubernetes.toml
+++ b/data/settings/1.41.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.42.x/kubernetes.toml
+++ b/data/settings/1.42.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.43.x/kubernetes.toml
+++ b/data/settings/1.43.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.44.x/kubernetes.toml
+++ b/data/settings/1.44.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.45.x/kubernetes.toml
+++ b/data/settings/1.45.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.46.x/kubernetes.toml
+++ b/data/settings/1.46.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.47.x/kubernetes.toml
+++ b/data/settings/1.47.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.48.x/kubernetes.toml
+++ b/data/settings/1.48.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.49.x/kubernetes.toml
+++ b/data/settings/1.49.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.50.x/kubernetes.toml
+++ b/data/settings/1.50.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"

--- a/data/settings/1.51.x/kubernetes.toml
+++ b/data/settings/1.51.x/kubernetes.toml
@@ -631,7 +631,7 @@ see = [
 
 [[docs.ref.seccomp-default]]
 description = "Enable `RuntimeDefault` as the default seccomp profile for all workloads via `kubelet-configuration`"
-default= "`false`"
+default= "`true` for k8s-1.33+ variants, `false` for other variants"
 accepted_values = [
     "`true`",
     "`false`"


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->


**Description of changes:**
- Switch `seccomp-default` to the correct default value. This was changed starting the `aws-k8s-1.33` variants [Reference](https://github.com/bottlerocket-os/bottlerocket/blob/47438798ce04fcc8a0b690dba268f374bd2eec7f/sources/settings-defaults/aws-k8s-1.33/defaults.d/56-kubernetes-seccomp-default-true.toml#L1)

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
