### PR TITLE
fix: update k8s node-labels setting example

### DIFF
--- a/data/settings/1.14.x/kubernetes.toml
+++ b/data/settings/1.14.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.15.x/kubernetes.toml
+++ b/data/settings/1.15.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.16.x/kubernetes.toml
+++ b/data/settings/1.16.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.17.x/kubernetes.toml
+++ b/data/settings/1.17.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.18.x/kubernetes.toml
+++ b/data/settings/1.18.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.19.x/kubernetes.toml
+++ b/data/settings/1.19.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.20.x/kubernetes.toml
+++ b/data/settings/1.20.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.21.x/kubernetes.toml
+++ b/data/settings/1.21.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.22.x/kubernetes.toml
+++ b/data/settings/1.22.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.23.x/kubernetes.toml
+++ b/data/settings/1.23.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.24.x/kubernetes.toml
+++ b/data/settings/1.24.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.25.x/kubernetes.toml
+++ b/data/settings/1.25.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.26.x/kubernetes.toml
+++ b/data/settings/1.26.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.27.x/kubernetes.toml
+++ b/data/settings/1.27.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.28.x/kubernetes.toml
+++ b/data/settings/1.28.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.29.x/kubernetes.toml
+++ b/data/settings/1.29.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.30.x/kubernetes.toml
+++ b/data/settings/1.30.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.31.x/kubernetes.toml
+++ b/data/settings/1.31.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.32.x/kubernetes.toml
+++ b/data/settings/1.32.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.33.x/kubernetes.toml
+++ b/data/settings/1.33.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.34.x/kubernetes.toml
+++ b/data/settings/1.34.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.35.x/kubernetes.toml
+++ b/data/settings/1.35.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.36.x/kubernetes.toml
+++ b/data/settings/1.36.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.37.x/kubernetes.toml
+++ b/data/settings/1.37.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.38.x/kubernetes.toml
+++ b/data/settings/1.38.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.39.x/kubernetes.toml
+++ b/data/settings/1.39.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.40.x/kubernetes.toml
+++ b/data/settings/1.40.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.41.x/kubernetes.toml
+++ b/data/settings/1.41.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.42.x/kubernetes.toml
+++ b/data/settings/1.42.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.43.x/kubernetes.toml
+++ b/data/settings/1.43.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.44.x/kubernetes.toml
+++ b/data/settings/1.44.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.45.x/kubernetes.toml
+++ b/data/settings/1.45.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.46.x/kubernetes.toml
+++ b/data/settings/1.46.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.47.x/kubernetes.toml
+++ b/data/settings/1.47.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.48.x/kubernetes.toml
+++ b/data/settings/1.48.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.49.x/kubernetes.toml
+++ b/data/settings/1.49.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.50.x/kubernetes.toml
+++ b/data/settings/1.50.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]

--- a/data/settings/1.51.x/kubernetes.toml
+++ b/data/settings/1.51.x/kubernetes.toml
@@ -80,7 +80,22 @@ description = "[Labels](https://kubernetes.io/docs/concepts/overview/working-wit
 tags = [
     "labels-and-taints"
 ]
-note = "Remember to quote keys (since they often contain `.`) and to quote all values."
+note = """
+For label keys: With TOML, if the key contains a dot (.) or slash (/), it must be quoted. With apiclient, if the key contains a dot (.), it must be set with the `--json` flag like:
+```
+apiclient set --json '{
+  "settings": {
+    "kubernetes": {
+      "node-labels": {
+        "label1.a": "foo"
+      }
+    }
+  }
+}'
+```
+
+For label values: With TOML, all values must be quoted. With apiclient, quotes are optional.
+"""
 
 see = [
     ["[Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)"]
@@ -88,8 +103,8 @@ see = [
 
 [[docs.ref.node-labels.example]]
 [[docs.ref.node-labels.example.multiline]]
-"label1" = "foo"
-"label2" = "bar"
+"\"label1/a\"" = "\"foo\""
+"label2" = "\"bar\""
 
 
 [[docs.ref.node-taints]]


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-project-website/issues/556

**Description of changes:**

Fixes `settings.kubernetes.node-labels` example as called out in the issue by @tcarreira. Also adds more details on the differences between TOML and apiclient for keys/values.

This setting exists for `v1.14.X` onwards.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
