### PR TITLE
docs: add image-verifier-plugins settings documentation

### DIFF
--- a/content/en/os/1.51.x/api/settings/image-verifier-plugins/_index.markdown
+++ b/content/en/os/1.51.x/api/settings/image-verifier-plugins/_index.markdown
@@ -1,0 +1,10 @@
++++
+title="image-verifier-plugins"
+type="docs"
+toc_hide=true
+description="Settings for configuring image verifier plugins (`settings.image-verifier-plugins.*`)"
++++
+
+**Note:** These settings are only available on aws-ecs-3 variants.
+
+{{< settings >}}

--- a/data/settings/1.51.x/image-verifier-plugins.toml
+++ b/data/settings/1.51.x/image-verifier-plugins.toml
@@ -1,0 +1,36 @@
+[[docs.ref.enabled]]
+description = """
+Controls whether image verifier plugins are enabled.
+When enabled, container images will be verified using the configured plugins before being allowed to run.
+"""
+default = "`false`"
+accepted_values = [
+    "`true`",
+    "`false`"
+]
+
+[[docs.ref.enabled.example]]
+value = "true"
+comment = "Enable image verifier plugins"
+
+[[docs.ref.notation]]
+description = """
+Configuration for Notation-based image verification.
+"""
+
+[[docs.ref.notation-trustpolicy]]
+name_override = "notation.trustpolicy"
+description = """
+Base64 encoded trustpolicy.json file for Notation verification.
+The trust policy defines which identities are trusted to sign container images and the verification requirements.
+"""
+accepted_values = [
+    "Base64 encoded JSON string"
+]
+see = [
+    ["[Notation Trust Policy Specification](https://github.com/notaryproject/specifications/blob/main/specs/trust-store-trust-policy.md#trust-policy)"]
+]
+
+[[docs.ref.notation-trustpolicy.example]]
+value = "\"ewogICJ2ZXJzaW9uIjogIjEuMCIsCiAgInRydXN0UG9saWNpZXMiOiBbXQp9\""
+comment = "Base64 encoded empty trust policy"


### PR DESCRIPTION

<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Description of changes:**

Add documentation for settings.image-verifier-plugins settings introduced in Bottlerocket 1.51.0. These settings are only available on aws-ecs-3 variants and provide container image verification capabilities.

The settings include:
- enabled: boolean to control image verification
- notation.trustpolicy: base64 encoded trust policy for Notation verification

Tested locally with `make preview`

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
