### PR TITLE
Update Hugo to latest upstream version

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # based on known good environment
-      HUGO_VERSION: 0.123.8
+      HUGO_VERSION: 0.156.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,17 @@
 
 preview:
 	docker run --rm -it \
-		-v "${PWD}":/src \
+		-v "${PWD}":/project \
 		-p 1313:1313 \
-		hugomods/hugo:exts-0.123.8 \
-		hugo server -w --bind=0.0.0.0
+		ghcr.io/gohugoio/hugo:v0.156.0 \
+		server -w --bind=0.0.0.0
 
 preview_finch:
 	finch run --rm -it \
-		-v "${PWD}":/src \
+		-v "${PWD}":/project \
 		-p 1313:1313 \
-		hugomods/hugo:exts-0.123.8 \
-		hugo server -w --bind=0.0.0.0 --poll 700ms
+		ghcr.io/gohugoio/hugo:v0.156.0 \
+		server -w --bind=0.0.0.0 --poll 700ms
 
 mdlint:
 	docker run --rm \

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -43,7 +43,7 @@ $tan-link: #e96f00;
 $light: #fff;
 $light-text: #0a4158;
 $light-link: #e96f00;
-
+$yellow: #ffa630;
 /* replacement for black */
 $dark: #020e13;
 
@@ -58,7 +58,9 @@ $font-weight-bold: 600;
 
 $primary: $light;
 $body-color: $dark;
-
+// Restore bg-warning color avoiding docsy's bug where warning and danger
+// have the same colour
+$warning: $yellow;
 
 $td-sidebar-bg-color: $light;
 $td-sidebar-tree-root-color: $dark;

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/bottlerocket-os/project-website
 
-go 1.18
+go 1.24
 
-require github.com/google/docsy v0.4.0 // indirect
+require (
+	github.com/google/docsy v0.12.0 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,13 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.4.0 h1:Eyt2aiDC1fnw/Qq/9xnIqUU5n5Yyk4c8gX3nBDdTv/4=
 github.com/google/docsy v0.4.0/go.mod h1:vJjGkHNaw9bO42gpFTWwAUzHZWZEVlK46Kx7ikY5c7Y=
+github.com/google/docsy v0.12.0 h1:CddZKL39YyJzawr8GTVaakvcUTCJRAAYdz7W0qfZ2P4=
+github.com/google/docsy v0.12.0/go.mod h1:1bioDqA493neyFesaTvQ9reV0V2vYy+xUAnlnz7+miM=
 github.com/google/docsy/dependencies v0.4.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/includes/homepage/minimal.markdown
+++ b/includes/homepage/minimal.markdown
@@ -16,5 +16,5 @@ You can still interact with the system through privileged “host” containers 
 From host containers, you can explore the underlying operating system and even make changes to the running system’s settings via an API.
 
 {{< twocolfigure  colsplit="7" caption="You can totally login to a Bottlerocket node. The shell you’re logging into is actually in a container with privileged access to the resources of the underlying operating system." >}}
-    {{% readfile "includes/homepage/priv-container.svg" %}}
+    {{< os-readfile "includes/homepage/priv-container.svg" >}}
 {{</ twocolfigure>}}

--- a/includes/homepage/safe-update.markdown
+++ b/includes/homepage/safe-update.markdown
@@ -8,7 +8,7 @@ When you’re ready to update, let your orchestrator drain the node and then tel
 Bottlerocket will swap the partitions and boot with the new version atomically.
 
 {{< stackedfigure caption="Bottlerocket uses multiple partitions to manage updates. Changeover occurs atomically at reboot." >}}
-    {{% readfile "includes/homepage/update.svg" %}}
+    {{< os-readfile "includes/homepage/update.svg" >}}
 {{</ stackedfigure>}}
 
 Because system settings are accomplished through an API, Bottlerocket knows how to migrate these settings between versions.

--- a/includes/homepage/security-focused.markdown
+++ b/includes/homepage/security-focused.markdown
@@ -12,5 +12,5 @@ The root filesystem of Bottlerocket is immutable.
 Additionally, Bottlerocket has an always-enabled, enforced, restrictive [SELinux](https://selinuxproject.org/page/Main_Page) policy for the mutable filesystem that helps prevent containers from executing dangerous operations, even when running as root.
 
 {{< twocolfigure  alt="Diagram of storage security"  caption="Bottlerocket has many layers of protection against unintended changes to the system." >}}
-    {{% readfile "includes/homepage/dm-verity-selinux.svg" %}}
+    {{< os-readfile "includes/homepage/dm-verity-selinux.svg" >}}
 {{</ twocolfigure>}}

--- a/includes/homepage/worker-node-diagram.markdown
+++ b/includes/homepage/worker-node-diagram.markdown
@@ -1,3 +1,3 @@
 {{< twocolfigure colsplit="7"  alt="Diagram of cluster"  caption="Bottlerocket is an operating system for the worker nodes in an orchestrated container cluster." >}}
-    {{% readfile "includes/homepage/cluster.svg" %}}
+    {{< os-readfile "includes/homepage/cluster.svg" >}}
 {{</ twocolfigure>}}

--- a/layouts/partials/setting-list-item.html
+++ b/layouts/partials/setting-list-item.html
@@ -10,5 +10,5 @@
     </a>
 </code>
 {{ if .new }}
-<span class="badge badge-secondary">New for {{ .new }}</span>
+<span class="badge bg-warning">New for {{ .new }}</span>
 {{ end }}

--- a/layouts/partials/settings-example-tab-button.html
+++ b/layouts/partials/settings-example-tab-button.html
@@ -5,5 +5,5 @@
 {{- $active_tab := cond (eq (.Get "active") true) "active" "" -}}
 {{- $aria_selected := (eq (.Get "active") true) -}}
 <li class="nav-item" role="presentation">
-    <button class="nav-link {{ $active_tab }}" id="{{ $setting_id }}-example-{{$example_type}}-tab" data-toggle="tab" data-target="#{{ $setting_id }}Example{{$example_type}}Pane" type="button" role="tab" aria-controls="{{ $example_type }}" aria-selected="{{ $aria_selected }}">{{  $example_type }}</button>
+    <button class="nav-link {{ $active_tab }}" id="{{ $setting_id }}-example-{{$example_type}}-tab" data-bs-toggle="tab" data-bs-target="#{{ $setting_id }}Example{{$example_type}}Pane" type="button" role="tab" aria-controls="{{ $example_type }}" aria-selected="{{ $aria_selected }}">{{  $example_type }}</button>
 </li>

--- a/layouts/partials/settings-setting-individual.html
+++ b/layouts/partials/settings-setting-individual.html
@@ -16,7 +16,7 @@
 <div class="setting-individual">
     <h3 id="{{ $setting_id }}"><code>{{ $setting_full_name }}</code>
     {{ if $setting_deprecated }}
-        <span class="badge badge-secondary">Deprecated</span>
+        <span class="badge bg-warning">Deprecated</span>
     {{ end }}
     </h3>
     <p>{{ $setting_description | markdownify }}</p>

--- a/layouts/partials/settings-tag-individual.html
+++ b/layouts/partials/settings-tag-individual.html
@@ -12,8 +12,8 @@
                         <button 
                             class="nav-link {{ if (eq $count 0) }} active {{ end }}" 
                             id="{{ $tag_name }}-example-{{ $value.type }}-tab" 
-                            data-toggle="tab" 
-                            data-target="#{{ $tag_name }}Example{{ $value.type }}Pane" 
+                            data-bs-toggle="tab" 
+                            data-bs-target="#{{ $tag_name }}Example{{ $value.type }}Pane" 
                             type="button" 
                             role="tab" 
                             aria-controls="{{ $value.tab  }}" 

--- a/layouts/partials/settings_inner_page_link.html
+++ b/layouts/partials/settings_inner_page_link.html
@@ -5,6 +5,6 @@
 <li>
     <a href="#{{ $setting_link }}"><code>settings.{{$setting_root}}.{{ or $values.name_override $setting_name}}</code></a>
     {{ if $values.deprecated }}
-        <span class="badge badge-secondary">Deprecated</span>
+        <span class="badge bg-warning">Deprecated</span>
     {{ end }}
 </li>

--- a/layouts/shortcodes/on-github.html
+++ b/layouts/shortcodes/on-github.html
@@ -2,7 +2,7 @@
     <hr />
     <small>
         See a problem with this page? <a href="{{ $.Site.Data.repos.website.github_issue_url }}" target="#">File an issue</a>. All feedback is appreciated.<br />
-        You can also directly contribute a change to the <a href="{{ $.Site.Data.repos.website.github }}{{ $.Site.Data.repos.website.path_prefix }}{{ $.Site.Data.repos.website.content_path}}/{{ $.Page.File.Lang }}/{{ $.Page.File.Path }}" target="#">source file of this page on GitHub</a>.
+        You can also directly contribute a change to the <a href="{{ $.Site.Data.repos.website.github }}{{ $.Site.Data.repos.website.path_prefix }}{{ $.Site.Data.repos.website.content_path}}/{{ $.Page.Language.Lang }}/{{ $.Page.File.Path }}" target="#">source file of this page on GitHub</a>.
     </small>
 </div>
 <script>

--- a/layouts/shortcodes/os-readfile.html
+++ b/layouts/shortcodes/os-readfile.html
@@ -1,0 +1,1 @@
+{{- readFile (index .Params 0) | safeHTML -}}


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->


**Description of changes:**
This PR updates the Hugo build environment and Docsy theme to current versions, along with fixes for breaking changes introduced by the upgrade.

Dependency Updates
- Hugo: 0.123.8 → 0.156.0
- Docsy theme: v0.4.0 → v0.12.0
- Bootstrap: 4.6.1 → 5.3.6 (via Docsy)
- Go: 1.18 → 1.24

Compatibility Fixes

The Docsy v0.12.0 upgrade brings Bootstrap 5, which required several fixes:

1. Tab attributes - Bootstrap 5 changed the data attribute API from `data-toggle` to `data-bs-toggle`
2. Badge styling - Bootstrap 5 removed `badge-secondary`. Added custom SCSS to restore the project's orange badge styling.
3. SVG rendering - Docsy changed how `readFile` works internally. Added the `inlinesvg` shortcode to use Hugo's `os.readFile` directly.


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
