### PR TITLE
image-verifier-plugins: add new verifiers

### DIFF
--- a/content/en/os/1.63.x/api/settings/image-verifier-plugins/_index.markdown
+++ b/content/en/os/1.63.x/api/settings/image-verifier-plugins/_index.markdown
@@ -5,6 +5,6 @@ toc_hide=true
 description="Settings for configuring image verifier plugins (`settings.image-verifier-plugins.*`)"
 +++
 
-**Note:** These settings are only available on aws-ecs-3 variants.
+**Note:** These settings are only available on aws-ecs-3, aws-ecs-4, and Kubernetes variants with Kubernetes 1.33 and later.
 
 {{< settings >}}

--- a/content/en/os/1.64.x/api/settings/image-verifier-plugins/_index.markdown
+++ b/content/en/os/1.64.x/api/settings/image-verifier-plugins/_index.markdown
@@ -5,6 +5,6 @@ toc_hide=true
 description="Settings for configuring image verifier plugins (`settings.image-verifier-plugins.*`)"
 +++
 
-**Note:** These settings are only available on aws-ecs-3 variants.
+**Note:** These settings are only available on aws-ecs-3, aws-ecs-4, and Kubernetes variants with Kubernetes 1.33 and later.
 
 {{< settings >}}

--- a/data/settings/1.63.x/image-verifier-plugins.toml
+++ b/data/settings/1.63.x/image-verifier-plugins.toml
@@ -1,0 +1,55 @@
+[[docs.ref.digestion]]
+description = """
+Configuration for digest-based image verification.
+"""
+
+[[docs.ref.digestion-trustpolicy]]
+name_override = "digestion.trustpolicy"
+description = """
+Base64 encoded trust policy for digest verification.
+The trust policy lists the image digests that are allowed to be pulled.
+The decoded JSON has the format:
+```json
+{
+  "version": "1.0",
+  "trustedDigests": [
+    "sha256:...",
+    "sha256:...",
+    ...
+  ]
+}
+```
+"""
+accepted_values = [
+    "Base64 encoded JSON string"
+]
+
+[[docs.ref.digestion-trustpolicy.example]]
+value = "\"eyJ2ZXJzaW9uIjogIjEuMCIsICJ0cnVzdGVkRGlnZXN0cyI6IFsic2hhMjU2OmFiYzEyMy4uLiJdfQ==\""
+comment = "Base64 encoded digestion trust policy"
+
+[[docs.ref.custom-verifier]]
+name_override = "<custom-verifier>"
+description = """
+Configuration for custom verifier plugins.
+A bootstrap container with a custom image can be used to install a custom verifier binary to the host at boot.
+Custom verifier binaries must be installed to `/opt/civ/bin` and configuration files for a custom verifier can be provided at `/var/lib`.
+"""
+see = [
+    ["[Bootstrap Containers](../../../concepts/bootstrap-containers/)"],
+    ["[containerd Image Verification](https://github.com/containerd/containerd/blob/main/docs/image-verification.md)"]
+]
+
+[[docs.ref.custom-verifier-trustpolicy]]
+name_override = "<custom-verifier>.trustpolicy"
+description = """
+Base64 encoded trust policy for a custom verifier plugin.
+The trust policy is written to the host for the custom verifier to consume; its format is defined by the custom verifier.
+"""
+accepted_values = [
+    "Base64 encoded JSON string"
+]
+
+[[docs.ref.custom-verifier-trustpolicy.example]]
+value = "\"eyJjdXN0b21Db25maWciOiAidmFsdWUifQ==\""
+comment = "Base64 encoded custom configuration"


### PR DESCRIPTION
<!--- When modifying this file, please also update the Github Actions under the .github/workflows/ directory, as they use duplicates of this PR template in their PR creation steps. -->

**Issue**

Close https://github.com/bottlerocket-os/bottlerocket-project-website/issues/601

**Description of changes:**

Prepare settings for release of new image verifier plugins and their inclusion in aws-ecs-3 and aws-k8s-1.33.

This PR is in draft and will be rebased once a Bottlerocket release includes these settings - note that they are *not* included yet.

See preview at https://ginglis13.github.io/en/os/1.63.x/api/settings/image-verifier-plugins/

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
