### PR TITLE
docs: update cpu-manager-policy-options for v1.51.0+

### DIFF
--- a/data/settings/1.51.x/kubernetes.toml
+++ b/data/settings/1.51.x/kubernetes.toml
@@ -24,3 +24,28 @@ This setting is only available for Kubernetes 1.33 and later variants.
 see = [
     ["[User Namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/#id-count-for-each-of-pods)"]
 ]
+
+[[docs.ref.cpu-manager-policy-options]]
+description = """
+Policy options to apply when `settings.kubernetes.cpu-manager-policy` is set to `static`.
+This setting is optional; when omitted all options default to disabled.
+"""
+note = """
+Not all combinations of policy options are valid.
+Refer to the [upstream Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-policy-static--options) for details on which options can be used together.
+"""
+see = [
+    ["[Static policy options](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-policy-static--options)"],
+    ["[`cpuManagerPolicyOptions` in Kubelet Configuration](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)"],
+    ["settings", "kubernetes", "cpu-manager-policy"]
+]
+accepted_values = [
+    "`full-pcpus-only`",
+    "`distribute-cpus-across-numa`",
+    "`strict-cpu-reservation`",
+    "`prefer-align-cpus-by-uncorecache`"
+]
+
+[[docs.ref.cpu-manager-policy-options.example]]
+comment = "When `settings.kubernetes.cpu-manager-policy` is set to `static`"
+value = "[\"full-pcpus-only\", \"distribute-cpus-across-numa\"]"


### PR DESCRIPTION
## Summary

- Updates `cpu-manager-policy-options` documentation starting from v1.51.x to list all four supported static policy options: `full-pcpus-only`, `distribute-cpus-across-numa`, `strict-cpu-reservation`, and `prefer-align-cpus-by-uncorecache`
- Clarifies that the setting is optional and all options default to disabled when omitted
- Adds a note that not all combinations of policy options are valid, linking to upstream Kubernetes documentation

Closes #577

## Test plan

- [x] Run `hugo server` and verify [/en/os/1.62.x/api/settings/kubernetes/#cpu-manager-policy-options](http://localhost:1313/en/os/1.62.x/api/settings/kubernetes/#cpu-manager-policy-options) shows all four accepted values and the compatibility note
- [x] Verify [/en/os/1.50.x/api/settings/kubernetes/#cpu-manager-policy-options](http://localhost:1313/en/os/1.50.x/api/settings/kubernetes/#cpu-manager-policy-options) still shows only `full-pcpus-only`
- [x] Verify intermediate versions (e.g. 1.54.x, 1.57.x) also show the updated options